### PR TITLE
Draft #3.

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -128,51 +128,51 @@
 
 (define (interval-dimension interval)
   (cond ((not (interval? interval))
-	 (error "interval-dimension: argument is not an interval: " interval))
+	 (error "interval-dimension: The argument is not an interval: " interval))
 	(else
 	 (##interval-dimension interval))))
 
 (define (interval-lower-bound interval i)
   (cond ((not (interval? interval))
-	 (error "interval-lower-bound: argument is not an interval: " interval i))
+	 (error "interval-lower-bound: The first argument is not an interval: " interval i))
 	((not (exact-integer? i))
-	 (error "interval-lower-bound: argument is not an exact integer: " interval i))
+	 (error "interval-lower-bound: The second argument is not an exact integer: " interval i))
 	((not (< -1 i (##interval-dimension interval)))
-	 (error "interval-lower-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
+	 (error "interval-lower-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
 	(else
 	 (##interval-lower-bound interval i))))
 
 (define (interval-upper-bound interval i)
   (cond ((not (interval? interval))
-	 (error "interval-upper-bound: argument is not an interval: " interval i))
+	 (error "interval-upper-bound: The first argument is not an interval: " interval i))
 	((not (exact-integer? i))
-	 (error "interval-upper-bound: argument is not an exact integer: " interval i))
+	 (error "interval-upper-bound: The second argument is not an exact integer: " interval i))
 	((not (< -1 i (##interval-dimension interval)))
-	 (error "interval-upper-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
+	 (error "interval-upper-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
 	(else
 	 (##interval-upper-bound interval i))))
 
 (define (interval-lower-bounds->vector interval)
   (cond ((not (interval? interval))
-	 (error "interval-lower-bounds->vector: argument is not an interval: " interval))
+	 (error "interval-lower-bounds->vector: The argument is not an interval: " interval))
 	(else
 	 (##interval-lower-bounds->vector interval))))
 
 (define (interval-upper-bounds->vector interval)
   (cond ((not (interval? interval))
-	 (error "interval-upper-bounds->vector: argument is not an interval: " interval))
+	 (error "interval-upper-bounds->vector: The argument is not an interval: " interval))
 	(else
 	 (##interval-upper-bounds->vector interval))))
 
 (define (interval-lower-bounds->list interval)
   (cond ((not (interval? interval))
-	 (error "interval-lower-bounds->list: argument is not an interval: " interval))
+	 (error "interval-lower-bounds->list: The argument is not an interval: " interval))
 	(else
 	 (##interval-lower-bounds->list interval))))
 
 (define (interval-upper-bounds->list interval)
   (cond ((not (interval? interval))
-	 (error "interval-upper-bounds->list: argument is not an interval: " interval))
+	 (error "interval-upper-bounds->list: The argument is not an interval: " interval))
 	(else
 	 (##interval-upper-bounds->list interval))))
 
@@ -347,7 +347,7 @@
 
 (define (interval-volume interval)
   (cond ((not (interval? interval))
-	 (error "interval-volume: argument is not an interval: " interval))
+	 (error "interval-volume: The argument is not an interval: " interval))
 	(else
 	 (##interval-volume interval))))
 
@@ -438,14 +438,14 @@
   ;; significantly simplifies testing the error checking
 
   (cond ((not (interval? interval))
-	 (error "interval-contains-multi-index?: argument is not an interval: " interval))
+	 (error "interval-contains-multi-index?: The first argument is not an interval: " interval))
 	(else
 	 (let ((multi-index (cons i multi-index-tail)))
 	   (cond ((not (= (##interval-dimension interval)
 			  (length multi-index)))
-		  (apply error "interval-contains-multi-index?: dimension of interval does not match number of arguments: " interval multi-index))
+		  (apply error "interval-contains-multi-index?: The dimension of the first argument (an interval) does not match number of indices: " interval multi-index))
 		 ((not (##every exact-integer? multi-index))
-		  (apply error "interval-contains-multi-index?: at least one multi-index component is not an exact integer: " interval multi-index))
+		  (apply error "interval-contains-multi-index?: At least one multi-index component is not an exact integer: " interval multi-index))
 		 (else
 		  (##interval-contains-multi-index?-general interval multi-index)))))))
 
@@ -454,9 +454,9 @@
 
 (define (interval-for-each f interval)
   (cond ((not (interval? interval))
-	 (error "interval-for-each: Argument is not a interval: " interval))
+	 (error "interval-for-each: The second argument is not a interval: " interval))
 	((not (procedure? f))
-	 (error "interval-for-each: Argument is not a procedure: " f))
+	 (error "interval-for-each: The first argument is not a procedure: " f))
 	(else
 	 (##interval-for-each f interval))))
 
@@ -723,19 +723,19 @@
 
 (define (array-domain obj)
   (cond ((not (array? obj))
-	 (error "array-domain: object is not an array: " obj))
+	 (error "array-domain: The argument is not an array: " obj))
 	(else
 	 (##array-base-domain obj))))
 
 (define (array-getter obj)
   (cond ((not (array? obj))
-	 (error "array-getter: object is not an array: " obj))
+	 (error "array-getter: The argument is not an array: " obj))
 	(else
 	 (##array-base-getter obj))))
 
 (define (array-dimension array)
   (cond ((not (array? array))
-	 (error "array-dimension: argument is not an array: " array))
+	 (error "array-dimension: The argument is not an array: " array))
 	(else
 	 (##interval-dimension (array-domain array)))))
 
@@ -768,7 +768,7 @@
 
 (define (array-setter obj)
   (cond ((not (mutable-array? obj))
-	 (error "array-setter: object is not an mutable array: " obj))
+	 (error "array-setter: The argument is not an mutable array: " obj))
 	(else
 	 (##array-base-setter obj))))
 
@@ -1259,25 +1259,25 @@
 
 (define (array-body obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-body: argument is not a specialized array: " obj))
+	 (error "array-body: The argument is not a specialized array: " obj))
 	(else
 	 (##array-base-body obj))))
 
 (define (array-indexer obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-indexer: argument is not a specialized array: " obj))
+	 (error "array-indexer: The argument is not a specialized array: " obj))
 	(else
 	 (##array-base-indexer obj))))
 
 (define (array-storage-class obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-storage-class: argument is not a specialized array: " obj))
+	 (error "array-storage-class: The argument is not a specialized array: " obj))
 	(else
 	 (##array-base-storage-class obj))))
 
 (define (array-safe? obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-safe?: argument is not a specialized array: " obj))
+	 (error "array-safe?: The argument is not a specialized array: " obj))
 	(else
 	 (##array-base-safe? obj))))
 
@@ -1528,11 +1528,11 @@
                                   (result-storage-class generic-storage-class)
                                   (safe? (specialized-array-default-safe?)))
   (cond ((not (array? array))
-	 (error "array->specialized-array: Argument is not an array: " array))
+	 (error "array->specialized-array: The first argument is not an array: " array))
 	((not (storage-class? result-storage-class))
-	 (error "array->specialized-array: result-storage-class is not a storage-class: " result-storage-class))
+	 (error "array->specialized-array: The second argument is not a storage-class: " result-storage-class))
 	((not (boolean? safe?))
-	 (error "array->specialized-array: safe? is not a boolean: " safe?))
+	 (error "array->specialized-array: The third argument is not a boolean: " safe?))
 	(else
 	 (let* ((domain               (array-domain array))
 		(result               (make-specialized-array domain
@@ -2061,6 +2061,19 @@
 
 (setup-permuted-getters-and-setters)
 
+(define (##array-permute array permutation)
+  (cond ((specialized-array? array)
+         (specialized-array-share array
+                                  (##interval-permute (array-domain array) permutation)
+                                  (##getter-permute values permutation)))
+        ((mutable-array? array)
+         (make-array (##interval-permute (array-domain array) permutation)
+                     (##getter-permute (array-getter array) permutation)
+                     (##setter-permute (array-setter array) permutation)))
+        (else
+         (make-array (##interval-permute (array-domain array) permutation)
+                     (##getter-permute (array-getter array) permutation)))))
+
 (define (##immutable-array-permute array permutation)
   (make-array (##interval-permute (array-domain array) permutation)
 	      (##getter-permute (array-getter array) permutation)))
@@ -2083,12 +2096,34 @@
 	((not (fx= (array-dimension array)
 		   (vector-length permutation)))
 	 (error "array-permute: The dimension of the first argument (an array) does not equal the dimension of the second argument (a permutation): " array permutation))
-	((specialized-array? array)
-	 (##specialized-array-permute array permutation))
-	((mutable-array? array)
-	 (##mutable-array-permute array permutation))
 	(else
-	 (##immutable-array-permute array permutation))))
+	 (##array-permute array permutation))))
+
+(define (array-rotate array dim)
+  (if (not (array? array))
+      (error "array-rotate: The first argument is not an array: " array dim)
+      (let ((d (array-dimension array)))
+        (if (not (and (fixnum? dim)
+                      (fx< -1 dim d)))
+            (error "array-rotate: The second argument is not an exact integer betweeen 0 (inclusive) and the array-dimension of the first argument (exclusive): " array dim)
+            (let ((permutation
+                   (let ((result (make-vector d)))
+                     (let left-loop ((i 0)
+                                     (j dim))
+                       (if (fx< j d)
+                           (begin
+                             (vector-set! result i j)
+                             (left-loop (fx+ i 1)
+                                        (fx+ j 1)))
+                           (let right-loop ((i i)
+                                            (j 0))
+                             (if (fx< i d)
+                                 (begin
+                                   (vector-set! result i j)
+                                   (right-loop (fx+ i 1)
+                                               (fx+ j 1)))
+                                 result)))))))
+              (##array-permute array permutation))))))
 
 (define-macro (setup-reversed-getters-and-setters)
 
@@ -2181,21 +2216,24 @@
 			   (array-domain array)
 			   (##getter-reverse values flip? (array-domain array))))
 
-(define (array-reverse array flip?)
-  (cond ((not (array? array))
-	 (error "array-reverse: The first argument is not an array: " array flip?))
-	((not (and (vector? flip?)
-		   (##vector-every boolean? flip?)))
-	 (error "array-reverse: The second argument is not a vector of booleans: " array flip?))
-	((not (fx= (array-dimension array)
-		   (vector-length flip?)))
-	 (error "array-reverse: The dimension of the first argument (an array) does not equal the dimension of the second argument (a vector of booleans): " array flip?))
-	((specialized-array? array)
-	 (##specialized-array-reverse array flip?))
-	((mutable-array? array)
-	 (##mutable-array-reverse array flip?))
-	(else
-	 (##immutable-array-reverse array flip?))))
+(define (array-reverse array #!optional (flip? (macro-absent-obj)))
+  (if  (not (array? array))
+       (error "array-reverse: The first argument is not an array: " array flip?)
+       (let ((flip? (if (eq? flip? (macro-absent-obj))
+                        (make-vector (array-dimension array) #t)
+                        flip?)))
+         (cond ((not (and (vector? flip?)
+                          (##vector-every boolean? flip?)))
+                (error "array-reverse: The second argument is not a vector of booleans: " array flip?))
+               ((not (fx= (array-dimension array)
+                          (vector-length flip?)))
+                (error "array-reverse: The dimension of the first argument (an array) does not equal the dimension of the second argument (a vector of booleans): " array flip?))
+               ((specialized-array? array)
+                (##specialized-array-reverse array flip?))
+               ((mutable-array? array)
+                (##mutable-array-reverse array flip?))
+               (else
+                (##immutable-array-reverse array flip?))))))
 
 
 
@@ -2795,6 +2833,64 @@
 	 (error "array-fold-right: The third argument is not an array: " op id a))
 	(else
 	 (##array-fold op id (array-reverse a (make-vector (array-dimension a) #t))))))
+
+(define (array-reduce sum A)
+  (cond ((not (array? A))
+         (error "array-reduce: The second argument is not an array: " sum A))
+        ((not (procedure? sum))
+         (error "array-reduce: The first argument is not a procedure: " sum A))
+        (else
+         (case (array-dimension A)
+           ((1) (let ((box '())
+                      (A_ (array-getter A)))
+                  (interval-for-each
+                   (lambda (i)
+                     (if (null? box)
+                         (set! box (list (A_ i)))
+                         (set-car! box (sum (car box)
+                                            (A_ i)))))
+                   (array-domain A))
+                  (car box)))
+           ((2) (let ((box '())
+                      (A_ (array-getter A)))
+                  (interval-for-each
+                   (lambda (i j)
+                     (if (null? box)
+                         (set! box (list (A_ i j)))
+                         (set-car! box (sum (car box)
+                                            (A_ i j)))))
+                   (array-domain A))
+                  (car box)))
+           ((3) (let ((box '())
+                      (A_ (array-getter A)))
+                  (interval-for-each
+                   (lambda (i j k)
+                     (if (null? box)
+                         (set! box (list (A_ i j k)))
+                         (set-car! box (sum (car box)
+                                            (A_ i j k)))))
+                   (array-domain A))
+                  (car box)))
+           ((4) (let ((box '())
+                      (A_ (array-getter A)))
+                  (interval-for-each
+                   (lambda (i j k l)
+                     (if (null? box)
+                         (set! box (list (A_ i j k l)))
+                         (set-car! box (sum (car box)
+                                            (A_ i j k l)))))
+                   (array-domain A))
+                  (car box)))
+           (else (let ((box '())
+                       (A_ (array-getter A)))
+                   (interval-for-each
+                    (lambda args
+                      (if (null? box)
+                          (set! box (list (apply A_ args)))
+                          (set-car! box (sum (car box)
+                                             (apply A_ args)))))
+                    (array-domain A))
+                   (car box)))))))
 
 (define (array->list array)
   (cond ((not (array? array))

--- a/srfi-179.html
+++ b/srfi-179.html
@@ -17,12 +17,12 @@
     <h2>Author</h2>
     <p>Bradley J. Lucier</p>
     <h2>Status</h2>
-    <p>This SRFI is currently in <em>draft</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+179+at+srfi+dotschemers+dot+org">srfi-179@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-179">archive</a>.</p>
+    <p>This SRFI is currently in <em>draft</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+179+at+srfi+dotschemers+dot+org">srfi-179@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-179">archive</a>.  There is a <a href="https://github.com/scheme-requests-for-implementation/srfi-179">git repository</a> of this document, a reference implementation, a test file, and other materials.</p>
     <ul>
       <li>Received: 2020/1/11</li>
       <li>60-day deadline: 2020/3/13</li>
-      <li>Draft #1 published: 2019/10/16</li>
-    </ul>
+      <li>Draft #1 published: 2020/1/11</li>
+      <li>Draft #2 published: 2020/1/27</li></ul>
     <h2>Abstract</h2>
     <p>This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a mapping, or function, from multi-indices of exact integers $i_0,\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices $i_0,\ldots,i_{d-1}$ that are valid for a given array form the <i>domain</i> of the array.  In this SRFI, each array's domain consists  of the cross product of nonempty intervals of exact integers $[l_0,u_0)\times[l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$ of $\mathbb Z^d$, $d$-tuples of integers.  Thus, we introduce a data type called $d$-<i>intervals</i>, or more briefly <i>intervals</i>, that encapsulates this notion. (We borrow this terminology from, e.g.,  Elias Zakon's <a href="http://www.trillia.com/zakon1.html">Basic Concepts of Mathematics</a>.) Specialized variants of arrays are specified to provide portable programs with efficient representations for common use cases.</p>
     <h2>Rationale</h2>
@@ -35,10 +35,10 @@
       <li>Encourage <b>bulk processing of arrays</b> rather than word-by-word operations.</li></ul>
     <p>This SRFI differs from the finalized <a href="https://srfi.schemers.org/srfi-122/">SRFI-122</a> in the following ways:</p>
     <ul>
-      <li>The procedures <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-assign!</code>, and <code>array-swap!</code> have been added.</li>
+      <li>The procedures <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-rotate</code>, <code>array-reduce</code>, <code>array-assign!</code>, and <code>array-swap!</code> have been added together with some examples.</li>
       <li>The discussion of Haar transforms as examples of separable transforms has been corrected.</li>
       <li>The documentation has a few more examples of image processing algorithms.</li>
-      <li>Some matrix examples have been added to this document and test-arrays.scm.</li></ul>
+      <li>Some matrix examples have been added to this document.</li></ul>
     <h2>Overview</h2>
     <h3>Bawden-style arrays</h3>
     <p>In a <a href="https://groups.google.com/forum/?hl=en#!msg/comp.lang.scheme/7nkx58Kv6RI/a5hdsduFL2wJ">1993 post</a> to the news group comp.lang.scheme, Alan Bawden gave a simple implementation of multi-dimensional arrays in R4RS scheme. The only constructor of new arrays required specifying an initial value, and he provided the three low-level primitives <code>array-ref</code>, <code>array-set!</code>, and <code>array?</code>.  His arrays were defined on rectangular intervals in $\mathbb Z^d$ of the form $[0,u_0)\times\cdots\times [0,u_{d-1})$.  I'll note that his function <code>array-set!</code> put the value to be entered into the array at the front of the variable-length list of indices that indicate where to place the new value.  He offered an intriguing way to &quot;share&quot; arrays in the form of a routine <code>make-shared-array</code> that took a mapping from a new interval of indices into the domain of the array to be shared.  His implementation incorporated what he called an <i>indexer</i>, which was a function from the interval $[0,u_0)\times\cdots\times [0,u_{d-1})$ to an interval $[0,N)$, where the <i>body</i> of the array consisted of a single Scheme vector of length $N$.  Bawden called the mapping specified in <code>make-shared-array</code> <i>linear</i>, but I prefer the term <i>affine</i>, as I explain later.</p>
@@ -56,13 +56,13 @@
       <li><b>Restricting the domain of an array: </b>  If the domain of $B$, $D_B$, is a subset of the domain of $A$, then $T_{BA}(\vec i)=\vec i$ is a one-to-one affine mapping.  We define <code>array-extract</code> to define this common operation; it's like looking at a rectangular sub-part of a spreadsheet. We use it to extract the common part of overlapping domains of three arrays in an image processing example below. </li>
       <li><b>Tiling an array: </b>For various reasons (parallel processing, optimizing cache localization, GPU programming, etc.) one may wish to process a large array as a number of subarrays of the same dimensions, which we call <i>tiling</i> the array.  The routine <code>array-tile</code> returns a new array, each entry of which is a subarray extracted (in the sense of <code>array-extract</code>) from the input array.</li>
       <li><b>Translating the domain of an array: </b>If $\vec d$ is a vector of integers, then $T_{BA}(\vec i)=\vec i-\vec d$ is a one-to-one affine map of $D_B=\{\vec i+\vec d\mid \vec i\in D_A\}$ onto $D_A$. We call $D_B$ the <i>translate</i> of $D_A$, and we define <code>array-translate</code> to provide this operation.</li>
-      <li><b>Permuting the coordinates of an array: </b>If $\pi$ <a href="https://en.wikipedia.org/wiki/Permutation">permutes</a> the coordinates of a multi-index $\vec i$, and $\pi^{-1}$ is the inverse of $\pi$, then $T_{BA}(\vec i)=\pi (\vec i)$ is a one-to-one affine map from $D_B=\{\pi^{-1}(\vec i)\mid \vec i\in D_A\}$ onto $D_A$.  We provide <code>array-permute</code> for this operation. The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.</li>
+      <li><b>Permuting the coordinates of an array: </b>If $\pi$ <a href="https://en.wikipedia.org/wiki/Permutation">permutes</a> the coordinates of a multi-index $\vec i$, and $\pi^{-1}$ is the inverse of $\pi$, then $T_{BA}(\vec i)=\pi (\vec i)$ is a one-to-one affine map from $D_B=\{\pi^{-1}(\vec i)\mid \vec i\in D_A\}$ onto $D_A$.  We provide <code>array-permute</code> for this operation. (The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) We also provide <code>array-rotate</code> for the special permutations that just rotate the axes.</li>
       <li><b>Currying an array: </b>Let's denote the cross product of two intervals $\text{Int}_1$ and $\text{Int}_2$ by $\text{Int}_1\times\text{Int}_2$; if $\vec j=(j_0,\ldots,j_{r-1})\in \text{Int}_1$ and $\vec i=(i_0,\ldots,i_{s-1})\in \text{Int}_2$, then $\vec j\times\vec i$, which we define to be $(j_0,\ldots,j_{r-1},i_0,\ldots,i_{s-1})$, is in $\text{Int}_1\times\text{Int}_2$. If $D_A=\text{Int}_1\times\text{Int}_2$ and $\vec j\in\text{Int}_1$, then $T_{BA}(\vec i)=\vec j\times\vec i$ is a one-to-one affine mapping from $D_B=\text{Int}_2$ into $D_A$.  For each vector $\vec j$ we can compute a new array in this way; we provide <code>array-curry</code> for this operation, which returns an array whose domain is $\text{Int}_1$ and whose elements are themselves arrays, each of which is defined on $\text{Int}_2$. Currying a two-dimensional array would be like organizing a spreadsheet into a one-dimensional array of rows of the spreadsheet.</li>
-      <li><b>Traversing some indices in a multi-index in reverse order: </b>Consider an array $A$ with domain $D_A=[l_0,u_0)\times\cdots\times[l_{d-1},u_{d-1})$. Fix $D_B=D_A$ and assume we're given a vector of booleans $F$ ($F$ for &quot;flip?&quot;). Then define $T_{BA}:D_B\to D_A$ by $i_j\to i_j$ if $F_j$ is <code>#f</code> and $i_j\to u_j+l_j-1-i_j$ if  $F_j$ is <code>#t</code>.In other words,  we reverse the ordering of the $j$th coordinate of $\vec i$ if and only if $F_j$ is true. $T_{BA}$ is an affine mapping from $D_B\to D_A$, which defines a new array $B$, and we can provide <code>array-reverse</code> for this operation. Applying <code>array-reverse</code> to a two-dimensional spreadsheet might reverse the order of the rows or columns (or both).</li>
-      <li><b>Uniformly sampling an array: </b>Assume that $A$ is an array with domain $[0,u_1)\times\cdots\times[0,u_{d-1})$ (i.e., an interval all of whose lower bounds are zero). We'll also assume the existence of vector $S$ of scale factors, which are positive exact integers. Let $D_B$ be a new interval with $j$th lower bound equal to zero and $j$th upper bound equal to $\operatorname{ceiling}(u_j/S_j)$ and let $T_{BA}(\vec i)_j=i_j\times S_j$, i.e., the $j$th coordinate is scaled by $S_j$.  ($D_B$ contains precisely those multi-indices that $T_{BA}$ maps into $D_A$.)  Then $T_{BA}$ is an affine one-to-one mapping, and we provide <code>interval-scale</code> and <code>array-sample</code> for these operations.</li></ul>
+      <li><b>Traversing some indices in a multi-index in reverse order: </b>Consider an array $A$ with domain $D_A=[l_0,u_0)\times\cdots\times[l_{d-1},u_{d-1})$. Fix $D_B=D_A$ and assume we're given a vector of booleans $F$ ($F$ for &quot;flip?&quot;). Then define $T_{BA}:D_B\to D_A$ by $i_j\to i_j$ if $F_j$ is <code>#f</code> and $i_j\to u_j+l_j-1-i_j$ if  $F_j$ is <code>#t</code>. In other words,  we reverse the ordering of the $j$th coordinate of $\vec i$ if and only if $F_j$ is true. $T_{BA}$ is an affine mapping from $D_B\to D_A$, which defines a new array $B$, and we can provide <code>array-reverse</code> for this operation. Applying <code>array-reverse</code> to a two-dimensional spreadsheet might reverse the order of the rows or columns (or both).</li>
+      <li><b>Uniformly sampling an array: </b>Assume that $A$ is an array with domain $[0,u_1)\times\cdots\times[0,u_{d-1})$ (i.e., an interval all of whose lower bounds are zero). We'll also assume the existence of vector $S$ of scale factors, which are positive exact integers. Let $D_B$ be a new interval with $j$th lower bound equal to zero and $j$th upper bound equal to $\operatorname{ceiling}(u_j/S_j)$ and let $T_{BA}(\vec i)_j=i_j\times S_j$, i.e., the $j$th coordinate is scaled by $S_j$.  ($D_B$ contains precisely those multi-indices that $T_{BA}$ maps into $D_A$.) Then $T_{BA}$ is an affine one-to-one mapping, and we provide <code>interval-scale</code> and <code>array-sample</code> for these operations.</li></ul>
     <p>We make several remarks.  First, all these operations could have been computed by specifying the particular mapping $T_{BA}$ explicitly, so that these routines are simply &quot;convenience&quot; procedures.  Second, because the composition of any number of affine mappings are again affine, accessing or changing the elements of a restricted, translated, curried, permuted array is no slower than accessing or changing the elements of the original array itself. Finally, we note that by combining array currying and permuting, say, one can come up with simple expressions of powerful algorithms, such as extending one-dimensional transforms to multi-dimensional separable transforms, or quickly generating two-dimensional slices of three-dimensional image data. Examples are given below.</p>
     <h3>Generalized arrays</h3>
-    <p>Bawden-style arrays are clearly useful as a programming construct, but they do not fulfill all our needs in this area. An array, as commonly understood, provides a mapping from multi-indices  $(i_0,\ldots,i_{d-1})$ of exact integers 
+    <p>Bawden-style arrays are clearly useful as a programming construct, but they do not fulfill all our needs in this area. An array, as commonly understood, provides a mapping from multi-indices  $(i_0,\ldots,i_{d-1})$ of exact integers
       in a nonempty, rectangular, $d$-dimensional interval $[l_0,u_0)\times[l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$ (the <i>domain</i> of the array) to Scheme objects.
       Thus, two things are necessary to specify an array: an interval and a mapping that has that interval as its domain.</p>
     <p>Since these two things are often sufficient for certain algorithms, we introduce in this SRFI a minimal set of interfaces for dealing with such arrays.</p>
@@ -77,7 +77,7 @@
     <p>One could again &quot;share&quot; $B$, given a new interval $D_C$ as the domain of a new array $C$ and an affine transform $T_{CB}:D_C\to D_B$, and then each access $C(\vec i)=A(T_{BA}(T_{CB}(\vec i)))$.  The composition $T_{BA}\circ T_{CB}:D_C\to D_A$, being itself affine, could be precomputed and stored as $T_{CA}:D_C\to D_A$, and $C(\vec i)=A(T_{CA}(\vec i))$ can be computed with the overhead of computing a single affine transformation.</p>
     <p>So, if we wanted, we could share generalized arrays with constant overhead by adding a single layer of (multi-valued) affine transformations on top of evaluating generalized arrays.  Even though this could be done transparently to the user, we do not do that here; it would be a compatible extension of this SRFI to do so.  We provide only the routine <code>specialized-array-share</code>, not a more general <code>array-share</code>.</p>
     <p>Certain ways of sharing generalized arrays, however, are relatively easy to code and not that expensive.  If we denote <code>(array-getter A)</code> by <code>A-getter</code>, then if B is the result of <code>array-extract</code> applied to A, then <code>(array-getter B)</code> is simply <code>A-getter</code>.  Similarly, if A is a two-dimensional array, and B is derived from A by applying the permutation $\pi((i,j))=(j,i)$, then <code>(array-getter B)</code> is <code>(lambda (i j) (A-getter j i))</code>.  Translation and currying also lead to transformed arrays whose getters are relatively efficiently derived from <code>A-getter</code>, at least for arrays of small dimension.</p>
-    <p>Thus, while we do not provide for sharing of generalized arrays for general one-to-one affine maps $T$, we do allow it for the specific functions <code>array-extract</code>, <code>array-translate</code>, <code>array-permute</code>,  <code>array-curry</code>,  <code>array-reverse</code>, and <code>array-sample</code>,  and we provide relatively efficient implementations of these functions for arrays of dimension no greater than four.</p>
+    <p>Thus, while we do not provide for sharing of generalized arrays for general one-to-one affine maps $T$, we do allow it for the specific functions <code>array-extract</code>, <code>array-translate</code>, <code>array-permute</code>,  <code>array-curry</code>,  <code>array-reverse</code>, <code>array-tile</code>, <code>array-rotate</code> and <code>array-sample</code>,  and we provide relatively efficient implementations of these functions for arrays of dimension no greater than four.</p>
     <h3>Array-map does not produce a specialized array</h3>
     <p>Daniel Friedman and David Wise wrote a famous paper <a href="http://www.cs.indiana.edu/cgi-bin/techreports/TRNNN.cgi?trnum=TR44">CONS should not Evaluate its Arguments</a>. In the spirit of that paper, our procedure <code>array-map</code> does not immediately produce a specialized array, but a simple immutable array, whose elements are recomputed from the arguments of <code>array-map</code> each time they are accessed.   This immutable array can be passed on to further applications of <code>array-map</code> for further processing, without generating the storage bodies for intermediate arrays.</p>
     <p>We provide the procedure <code>array-&gt;specialized-array</code> to transform a generalized array (like that returned by <code>array-map</code>) to a specialized, Bawden-style array, for which accessing each element again takes $O(1)$ operations.</p>
@@ -87,9 +87,9 @@
     <ul>
       <li><b>Relationship to <a href="https://docs.racket-lang.org/math/array_nonstrict.html#%28tech._nonstrict%29">nonstrict arrays</a> in Racket. </b>It appears that what we call simply arrays in this SRFI are called nonstrict arrays in the math/array library of Racket, which in turn was influenced by an <a href="https://research.microsoft.com/en-us/um/people/simonpj/papers/ndp/RArrays.pdf">array proposal for Haskell</a>.  Our &quot;specialized&quot; arrays are related to Racket's &quot;strict&quot; arrays.</li>
       <li><b>Indexers. </b>The argument new-domain-&gt;old-domain to <code>specialized-array-share</code> is, conceptually, a multi-valued array.</li>
-      <li><b>Source of function names. </b>The function <code>array-curry</code> gets its name from the 
-        <a href="https://en.wikipedia.org/wiki/Currying">curry operator</a> in programming---we are currying the getter of the array and keeping careful track of the domains. 
-        <code>interval-projections</code> can be thought of as currying the 
+      <li><b>Source of function names. </b>The function <code>array-curry</code> gets its name from the
+        <a href="https://en.wikipedia.org/wiki/Currying">curry operator</a> in programming---we are currying the getter of the array and keeping careful track of the domains.
+        <code>interval-projections</code> can be thought of as currying the
         characteristic function of the interval,  encapsulated here as <code>interval-contains-multi-index?</code>.</li>
       <li><b>Choice of functions on intervals. </b>The choice of functions for both arrays and intervals was motivated almost solely by what I needed for arrays.</li>
       <li><b>No empty intervals. </b>This SRFI considers arrays over only nonempty intervals of positive dimension.  The author of this proposal acknowledges that other languages and array systems allow either zero-dimensional intervals or empty intervals of positive dimension, but prefers to leave such empty intervals as possibly compatible extensions to the current proposal.</li>
@@ -167,6 +167,7 @@
         <a href="#array-tile">array-tile</a>,
         <a href="#array-translate">array-translate</a>,
         <a href="#array-permute">array-permute</a>,
+        <a href="#array-rotate">array-rotate</a>,
         <a href="#array-reverse">array-reverse</a>,
         <a href="#array-sample">array-sample</a>,
         <a href="#array-outer-product">array-outer-product</a>,
@@ -174,6 +175,7 @@
         <a href="#array-for-each">array-for-each</a>,
         <a href="#array-fold">array-fold</a>,
         <a href="#array-fold-right">array-fold-right</a>,
+        <a href="#array-reduce">array-reduce</a>,
         <a href="#array-any">array-any</a>,
         <a href="#array-every">array-every</a>,
         <a href="#array-&gt;list">array-&gt;list</a>,
@@ -207,8 +209,8 @@
     <p>Create a new interval; <code><var>lower-bounds</var></code> and <code><var>upper-bounds</var></code>
       are nonempty vectors (of the same length) of exact integers that satisfy</p>
     <pre><code> (&lt; (vector-ref <var>lower-bounds</var> i) (vector-ref <var>upper-bounds</var> i))</code></pre>
-    <p> for 
-      $0\leq i&lt;{}$<code>(vector-length <var>lower-bounds</var>)</code>.  It is an error if 
+    <p> for
+      $0\leq i&lt;{}$<code>(vector-length <var>lower-bounds</var>)</code>.  It is an error if
       <code><var>lower-bounds</var></code> and <code><var>upper-bounds</var></code> do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="interval?">interval?</a> <var>obj</var></code></p>
     <p>Returns <code>#t</code> if <code><var>obj</var></code> is an interval, and <code>#f</code> otherwise.</p>
@@ -269,7 +271,7 @@
     <p>for $0\leq j &lt; d$, and <code>#f</code> otherwise.</p>
     <p>It is an error to call <code>interval-contains-multi-index?</code> if <code><var>interval</var></code> and <code><var>index-0</var></code>,..., do not satisfy this condition.</p>
     <p><b>Procedure: </b><code><a name="interval-projections">interval-projections</a> <var>interval</var> <var>right-dimension</var></code></p>
-    <p>Conceptually, <code>interval-projections</code> takes a $d$-dimensional interval 
+    <p>Conceptually, <code>interval-projections</code> takes a $d$-dimensional interval
       $[l_0,u_0)\times [l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$
       and splits it into two parts</p>
     <blockquote>$[l_0,u_0)\times\cdots\times[l_{d-\text{right-dimension}-1},u_{d-\text{right-dimension}-1})$
@@ -315,15 +317,15 @@
       nonempty interval.  It is an error if the arguments do not satisfy these conditions.</p>
     <p>Examples:</p>
     <pre><code>
-(interval= 
+(interval=
  (interval-dilate (make-interval '#(0 0) '#(100 100))
                   '#(1 1) '#(1 1))
  (make-interval '#(1 1) '#(101 101))) =&gt; #t
-(interval= 
+(interval=
  (interval-dilate (make-interval '#(0 0) '#(100 100))
                   '#(-1 -1) '#(1 1))
  (make-interval '#(-1 -1) '#(101 101))) =&gt; #t
-(interval= 
+(interval=
  (interval-dilate (make-interval '#(0 0) '#(100 100))
                   '#(0 0) '#(-50 -50))
  (make-interval '#(0 0) '#(50 50))) =&gt; #t
@@ -412,7 +414,7 @@
                       vector-set!
                       (lambda (arg) #t)
                       make-vector
-                      vector-length 
+                      vector-length
                       #f))</code></pre>Furthermore, <code>s<var>X</var>-storage-class</code> is defined for <code><var>X</var></code>=8, 16, 32, and 64 (which have default values 0 and
     manipulate exact integer values between -2<sup><var>X</var>-1</sup> and
     2<sup><var>X</var>-1</sup>-1 inclusive),
@@ -606,7 +608,7 @@ indexer:       (lambda multi-index
 (array-for-each (lambda (row)
                   (pretty-print (array-&gt;list row)))
                 (array-curry b 1))
-  
+
 ;; which prints
 ;; ((0 0) (0 1) (0 2) (0 3) (0 4))
 ;; ((1 1) (1 2) (1 3) (1 4) (1 5))
@@ -762,7 +764,7 @@ indexer:       (lambda multi-index
  <var>array</var>
  (interval-translate (array-domain <var>array</var>)
                      <var>translation</var>)
- (lambda multi-index 
+ (lambda multi-index
    (apply values
           (map -
                multi-index
@@ -771,7 +773,7 @@ indexer:       (lambda multi-index
     <p>that shares the body of <code><var>array</var></code>.</p>
     <p>If <code><var>array</var></code> is not a specialized array but is a mutable array, returns a new mutable array</p>
     <pre><code>
-(make-array 
+(make-array
  (interval-translate (array-domain <var>array</var>)
                      <var>translation</var>)
  (lambda multi-index
@@ -836,8 +838,11 @@ indexer:       (lambda multi-index
               (apply (array-getter <var>array</var>)
                      (&pi;<sup>-1</sup> multi-index))))</code></pre>
     <p>It is an error to call <code>array-permute</code> if its arguments do not satisfy these conditions.</p>
-    <p><b>Procedure: </b><code><a name="array-reverse">array-reverse</a> <var>array</var> <var>flip?</var></code></p>
-    <p>We assume that <code><var>array</var></code> is an array and <code><var>flip?</var></code> is a vector of booleans whose length is the same as the dimension of <code><var>array</var></code>.</p>
+    <p><b>Procedure: </b><code><a name="array-rotate">array-rotate</a> <var>array</var> <var>dim</var></code></p>
+    <p>Informally, <code>(array-rotate <var>array</var> <var>dim</var>)</code> rotates the axes of <code><var>array</var></code> <code><var>dim</var></code> places to the left.</p>
+    <p>More precisely, <code>(array-rotate <var>array</var> <var>dim</var>)</code> assumes that <code><var>array</var></code> is an array and <code><var>dim</var></code> is an exact integer between 0 (inclusive) and <code>(array-dimension <var>array</var>)</code> (exclusive).  It computes the permutation <code>(vector <var>dim</var> ... (- (array-dimension <var>array</var>) 1) 0 ... (- <var>dim</var> 1))</code> (unless <code><var>dim</var></code> is zero, in which case it constructs the identity permutation) and returns <code>(array-permute <var>array</var> <var>permutation</var>)</code>. It is an error if the arguments do not satisfy these conditions.</p>
+    <p><b>Procedure: </b><code><a name="array-reverse">array-reverse</a> <var>array</var> #!optional <var>flip?</var></code></p>
+    <p>We assume that <code><var>array</var></code> is an array and <code><var>flip?</var></code>, if given, is a vector of booleans whose length is the same as the dimension of <code><var>array</var></code>.  If <code><var>flip?</var></code> is not given, it is set to a vector with length the same as the dimension of <code><var>array</var></code>, all of whose elements are <code>#t</code>.</p>
     <p><code>array-reverse</code> returns a new array  that is specialized,  mutable, or immutable according to whether <code><var>array</var></code> is specialized, mutable, or immutable, respectively.  Informally, if <code>(vector-ref <var>flip?</var> k)</code> is true, then the ordering of multi-indices in the k'th coordinate direction is reversed, and is left undisturbed otherwise.</p>
     <p>More formally, we introduce the function </p>
     <pre><code>
@@ -881,6 +886,40 @@ indexer:       (lambda multi-index
    (apply (array-getter <code><var>array</var></code>)
           (flip-multi-index multi-index))))) </code></pre>
     <p>It is an error if <code><var>array</var></code> and <code><var>flip?</var></code> don't satisfy these requirements.</p>
+    <p>The following example using <code>array-reverse</code> was motivated by <a href="https://funcall.blogspot.com/2020/01/palindromes-redux-and-sufficiently.html">a blog post by Joe Marshall</a>.</p>
+    <pre><code>
+(define (palindrome? s)
+  (let ((n (string-length s)))
+    (or (&lt; n 2)
+        (let* ((a
+                ;; an array accessing the characters of s
+                (make-array (make-interval '#(0)
+                                           (vector n))
+                            (lambda (i)
+                              (string-ref s i))))
+               (ra
+                ;; the array accessed in reverse order
+                (array-reverse a))
+               (half-domain
+                (make-interval '#(0)
+                               (vector (quotient n 2)))))
+          (array-every
+           char=?
+           ;; the first half of s
+           (array-extract a half-domain)
+           ;; the reversed second half of s
+           (array-extract ra half-domain))))))
+
+(palindrome? &quot;&quot;) =&gt; #t
+(palindrome? &quot;a&quot;) =&gt; #t
+(palindrome? &quot;aa&quot;) =&gt; #t
+(palindrome? &quot;ab&quot;) =&gt; #f
+(palindrome? &quot;aba&quot;) =&gt; #t
+(palindrome? &quot;abc&quot;) =&gt; #f
+(palindrome? &quot;abba&quot;) =&gt; #t
+(palindrome? &quot;abca&quot;) =&gt; #f
+(palindrome? &quot;abbc&quot;) =&gt; #f
+</code></pre>
     <p><b>Procedure: </b><code><a name="array-sample">array-sample</a> <var>array</var> <var>scales</var></code></p>
     <p>We assume that <code><var>array</var></code> is an array all of whose lower bounds are zero, and <code><var>scales</var></code> is a vector of positive exact integers whose length is the same as the dimension of <code><var>array</var></code>.</p>
     <p><code>array-sample</code> returns a new array  that is specialized,  mutable, or immutable according to whether <code><var>array</var></code> is specialized, mutable, or immutable, respectively.  Informally, if we construct a new matrix $S$ with the entries of <code><var>scales</var></code> on the main diagonal, then the $\vec i$th element of <code>(array-sample <var>array</var> <var>scales</var>)</code> is the $S\vec i$th element of <code><var>array</var></code>.</p>
@@ -999,12 +1038,56 @@ indexer:       (lambda multi-index
 (fold-right kons knil lis)
     = (kons (car lis) (fold-right kons knil (cdr lis)))
 (fold-right kons knil '())
-    = knil 
+    = knil
 </code></pre>
     <p>then <code>(array-fold-right <var>kons</var> <var>knil</var> <var>array</var>)</code> returns </p>
     <pre><code>
 (fold-right <var>kons</var> <var>knil</var> (array-&gt;list <var>array</var>))</code></pre>
     <p>It is an error if <code><var>array</var></code> is not an array, or if <code><var>kons</var></code> is not a procedure.</p>
+    <p><b>Procedure: </b><code><a name="array-reduce">array-reduce</a> <var>op</var> <var>A</var></code></p>
+    <p>We assume that <code><var>A</var></code> is an array and <code><var>op</var></code> is a procedure of two arguments that is associative, i.e., <code>(<var>op</var> (<var>op</var> <var>x</var> <var>y</var>) <var>z</var>)</code> is the same as <code>(<var>op</var> <var>x</var> (<var>op</var>  <var>y</var> <var>z</var>))</code>.</p>
+    <p>Then <code>(array-reduce <var>op</var> <var>A</var>)</code> returns</p>
+    <pre><code>
+(let ((box '())
+      (A_ (array-getter A)))
+  (interval-for-each
+   (lambda args
+     (if (null? box)
+         (set! box (list (apply A_ args)))
+         (set-car! box (op (car box)
+                           (apply A_ args)))))
+   (array-domain A))
+  (car box))
+</code></pre>
+    <p>The implementation is allowed to use the associativity of <code><var>op</var></code> to reorder the computations in <code>array-reduce</code>. It is an error if the arguments do not satisfy these conditions.</p>
+    <p>As an example, we consider the finite sum:
+      $$
+      S_m=\sum_{k=1}^m \frac 1{k^2}.
+      $$
+      One can show that
+      $$
+      \frac 1 {m+1}&lt;\frac{\pi^2}6-S_m&lt;\frac 1m.
+      $$
+      We attempt to compute this in floating-point arithmetic in two ways. In the first, we apply <code>array-reduce</code> to an array containing the terms of the series, basically a serial computation.  In the second, we divide the series into blocks of no more than 1,000 consecutive terms, apply <code>array-reduce</code> to get a new sequence of terms, and repeat the process. The second way is approximately what might happen with GPU computing.</p>
+    <p> We find with $m=1{,}000{,}000{,}000$: </p>
+    <pre><code>
+(define A (make-array (make-interval '#(1) '#(1000000001))
+                      (lambda (k)
+                        (fl/ (flsquare (inexact k))))))
+(define (block-sum A)
+  (let ((N (interval-volume (array-domain A))))
+    (cond ((&lt;= N 1000)
+           (array-reduce fl+ A))
+          ((&lt;= N (square 1000))
+           (block-sum (array-map block-sum
+                                 (array-tile A (vector (integer-sqrt N))))))
+          (else
+           (block-sum (array-map block-sum
+                                 (array-tile A (vector (quotient N 1000)))))))))
+(array-reduce fl+ A) =&gt; 1.644934057834575
+(block-sum A)        =&gt; 1.6449340658482325
+</code></pre>
+    <p>Since $\pi^2/6\approx{}$<code>1.6449340668482264</code>, we see  using the first method that the difference $\pi^2/6-{}$<code>1.644934057834575</code>${}\approx{}$<code>9.013651380840315e-9</code> and with the second we have $\pi^2/6-{}$<code>1.6449340658482325</code>${}\approx{}$<code>9.99993865491433e-10</code>.  The true difference should be between $\frac 1{1{,}000{,}000{,}001}\approx{}$<code>9.99999999e-10</code> and $\frac 1{1{,}000{,}000{,}000}={}$<code>1e-9</code>. The difference for the first method is about 10 times too big, and, in fact, will not change further because any futher terms, when added to the partial sum, are too small to increase the sum after rounding-to-nearest in double-precision IEEE-754 floating-point arithmetic.</p>
     <p><b>Procedure: </b><code><a name="array-any">array-any</a> <var>pred</var> <var>array1</var> <var>array2</var> ...</code></p>
     <p>Assumes that <code><var>array1</var></code>, <code><var>array2</var></code>, etc., are arrays, all with the same domain, which we'll call <code>interval</code>.  Also assumes that <code><var>pred</var></code> is a procedure that takes as many arguments as there are arrays and returns a single value.</p>
     <p><code>array-any</code> first applies <code>(array-getter <var>array1</var>)</code>, etc., to the first element of <code>interval</code> in lexicographical order, to which values it then applies <code><var>pred</var></code>.</p>
@@ -1077,7 +1160,7 @@ indexer:       (lambda multi-index
 (define pgm-pixels cdr)
 
 (define (read-pgm file)
-  
+
   (define (read-pgm-object port)
     (skip-white-space port)
     (let ((o (read port)))
@@ -1086,17 +1169,17 @@ indexer:       (lambda multi-index
       (if (eof-object? o)
           (error &quot;reached end of pgm file&quot;)
           o)))
-  
+
   (define (skip-to-end-of-line port)
     (let loop ((ch (read-char port)))
       (if (not (eq? ch #\newline))
           (loop (read-char port)))))
-  
+
   (define (white-space? ch)
-    (case ch 
+    (case ch
       ((#\newline #\space #\tab) #t)
       (else #f)))
-  
+
   (define (skip-white-space port)
     (let ((ch (peek-char port)))
       (cond ((white-space? ch)
@@ -1106,7 +1189,7 @@ indexer:       (lambda multi-index
              (skip-to-end-of-line port)
              (skip-white-space port))
             (else #f))))
-  
+
   ;; The image file formats defined in netpbm
   ;; are problematical, because they read the data
   ;; in the header as variable-length ISO-8859-1 text,
@@ -1115,30 +1198,30 @@ indexer:       (lambda multi-index
   ;; as binary data.
   ;; So we give here a solution of how to deal
   ;; with these subtleties in Gambit Scheme.
-  
+
   (call-with-input-file
       (list path:          file
             char-encoding: 'ISO-8859-1
             eol-encoding:  'lf)
     (lambda (port)
-      
+
       ;; We're going to read text for a while,
       ;; then switch to binary.
       ;; So we need to turn off buffering until
       ;; we switch to binary.
-      
+
       (port-settings-set! port '(buffering: #f))
-      
+
       (let* ((header (read-pgm-object port))
              (columns (read-pgm-object port))
              (rows (read-pgm-object port))
              (greys (read-pgm-object port)))
-        
+
         ;; now we switch back to buffering
         ;; to speed things up
-        
+
         (port-settings-set! port '(buffering: #t))
-        
+
         (make-pgm
          greys
          (array-&gt;specialized-array
@@ -1316,7 +1399,7 @@ indexer:       (lambda multi-index
     <p><b>Viewing two-dimensional slices of three-dimensional data. </b>One example might be viewing two-dimensional slices of three-dimensional data in different ways.  If one has a $1024 \times 512\times 512$ 3D image of the body stored as a variable <code><var>body</var></code>, then one could get 1024 axial views, each $512\times512$, of this 3D body by <code>(array-curry <var>body</var> 2)</code>; or 512 median views, each $1024\times512$, by <code>(array-curry (array-permute <var>body</var> '#(1 0 2)) 2)</code>; or finally 512 frontal views, each again $1024\times512$ pixels, by <code>(array-curry (array-permute <var>body</var> '#(2 0 1)) 2)</code>; see <a href="https://en.wikipedia.org/wiki/Anatomical_plane">Anatomical plane</a>.</p>
     <p><b>Calculating second differences of images. </b>For another example, if a real-valued function is defined
       on a two-dimensional interval $I$, its second difference in the direction $d$ at the point $x$ is defined as $\Delta^2_df(x)=f(x+2d)-2f(x+d)+f(x)$,
-      and this function is defined only for those $x$ for which $x$, $x+d$, and $x+2d$ are all in $I$. See the beginning of the section on &quot;Moduli of smoothness&quot; in <a href="http://www.math.purdue.edu/~lucier/692/related_papers_summaries.html#Wavelets-and-approximation-theory">these notes on wavelets and approximation theory</a> for more details.</p>
+      and this function is defined only for those $x$ for which $x$, $x+d$, and $x+2d$ are all in $I$. See the beginning of the section on &quot;Moduli of smoothness&quot; in <a href="https://www.math.purdue.edu/~lucier/692/related_papers_summaries.html#Wavelets-and-approximation-theory">these notes on wavelets and approximation theory</a> for more details.</p>
     <p>Using this definition, the following code computes all second-order forward differences of an image in the directions
       $d,2 d,3 d,\ldots$, defined only on the domains where this makes sense: </p>
     <pre><code>
@@ -1527,7 +1610,7 @@ Second-differences in the direction $k\times (1,-1)$:
                         ((1) -1.)
                         (else 0.)))))))
   (display &quot;
-Initial image: 
+Initial image:
 &quot;)
   (pretty-print (list (array-domain image)
 		      (array-&gt;list image)))
@@ -1542,15 +1625,15 @@ Initial image:
 </code></pre>
     <p>This yields: </p>
     <pre>
-Initial image: 
-(#&lt;##interval #11 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt; 
+Initial image:
+(#&lt;##interval #11 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt;
  (1. 1. 1. 1. -1. -1. -1. -1. 0. 0. 0. 0. 0. 0. 0. 0.))
 
-Array of hyperbolic Haar wavelet coefficients: 
-(#&lt;##interval #11 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt; 
+Array of hyperbolic Haar wavelet coefficients:
+(#&lt;##interval #11 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt;
  (0. 0. 0. 0. 2.8284271247461894 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.))
 
-Reconstructed image: 
+Reconstructed image:
 (#&lt;##interval #11 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt;
  (.9999999999999996
   .9999999999999996
@@ -1580,7 +1663,7 @@ Reconstructed image:
                         ((0) 1.)
                         ((1) -1.)
                         (else 0.)))))))
-  (display &quot;\nInitial image: \n&quot;)
+  (display &quot;\nInitial image:\n&quot;)
   (pretty-print (list (array-domain image)
 		      (array-&gt;list image)))
   (Haar-transform image)
@@ -1594,15 +1677,15 @@ Reconstructed image:
 </pre>
     <p>This yields: </p>
     <pre>
-Initial image: 
-(#&lt;##interval #12 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt; 
+Initial image:
+(#&lt;##interval #12 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt;
  (1. 1. 1. 1. -1. -1. -1. -1. 0. 0. 0. 0. 0. 0. 0. 0.))
 
-Array of Haar wavelet coefficients: 
+Array of Haar wavelet coefficients:
 (#&lt;##interval #12 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt;
  (0. 0. 0. 0. 1.9999999999999998 0. 1.9999999999999998 0. 0. 0. 0. 0. 0. 0. 0. 0.))
 
-Reconstructed image: 
+Reconstructed image:
 (#&lt;##interval #12 lower-bounds: #(0 0) upper-bounds: #(4 4)&gt;
  (.9999999999999997
   .9999999999999997
@@ -1799,7 +1882,8 @@ Reconstructed image:
       <li><a name="SRFI-25" href="https://srfi.schemers.org/srfi-25/">SRFI 25: Multi-dimensional Array Primitives</a>, by Jussi Piitulainen.</li>
       <li><a name="SRFI-47" href="https://srfi.schemers.org/srfi-47/">SRFI 47: Array</a>, by Aubrey Jaffer.</li>
       <li><a name="SRFI-58" href="https://srfi.schemers.org/srfi-58/">SRFI 58: Array Notation</a>, by Aubrey Jaffer.</li>
-      <li><a name="SRFI-63" href="https://srfi.schemers.org/srfi-63/">SRFI 63: Homogeneous and Heterogeneous Arrays</a>, by Aubrey Jaffer.</li></ol>
+      <li><a name="SRFI-63" href="https://srfi.schemers.org/srfi-63/">SRFI 63: Homogeneous and Heterogeneous Arrays</a>, by Aubrey Jaffer.</li>
+      <li><a name="SRFI-164" href="https://srfi.schemers.org/srfi-164/">SRFI 164: Enhanced multi-dimensional Arrays</a>, by Per Bothner.</li></ol>
     <h2>Copyright</h2>
     <p>&copy; 2016, 2018 Bradley J Lucier. All Rights Reserved.</p>
     <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: </p>

--- a/srfi-179.html
+++ b/srfi-179.html
@@ -21,8 +21,9 @@
     <ul>
       <li>Received: 2020/1/11</li>
       <li>60-day deadline: 2020/3/13</li>
-      <li>Draft #1 published: 2020/1/11</li>
-      <li>Draft #2 published: 2020/1/27</li></ul>
+      <li>Draft #1 published: 2020/01/11</li>
+      <li>Draft #2 published: 2020/01/27</li>
+      <li>Draft #3 published: 2020/02/04</li></ul>
     <h2>Abstract</h2>
     <p>This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a mapping, or function, from multi-indices of exact integers $i_0,\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices $i_0,\ldots,i_{d-1}$ that are valid for a given array form the <i>domain</i> of the array.  In this SRFI, each array's domain consists  of the cross product of nonempty intervals of exact integers $[l_0,u_0)\times[l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$ of $\mathbb Z^d$, $d$-tuples of integers.  Thus, we introduce a data type called $d$-<i>intervals</i>, or more briefly <i>intervals</i>, that encapsulates this notion. (We borrow this terminology from, e.g.,  Elias Zakon's <a href="http://www.trillia.com/zakon1.html">Basic Concepts of Mathematics</a>.) Specialized variants of arrays are specified to provide portable programs with efficient representations for common use cases.</p>
     <h2>Rationale</h2>
@@ -35,7 +36,7 @@
       <li>Encourage <b>bulk processing of arrays</b> rather than word-by-word operations.</li></ul>
     <p>This SRFI differs from the finalized <a href="https://srfi.schemers.org/srfi-122/">SRFI-122</a> in the following ways:</p>
     <ul>
-      <li>The procedures <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-rotate</code>, <code>array-reduce</code>, <code>array-assign!</code>, and <code>array-swap!</code> have been added together with some examples.</li>
+      <li>The procedures <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>interval-rotate</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-rotate</code>, <code>array-reduce</code>, <code>array-assign!</code>, and <code>array-swap!</code> have been added together with some examples.</li>
       <li>The discussion of Haar transforms as examples of separable transforms has been corrected.</li>
       <li>The documentation has a few more examples of image processing algorithms.</li>
       <li>Some matrix examples have been added to this document.</li></ul>
@@ -56,7 +57,7 @@
       <li><b>Restricting the domain of an array: </b>  If the domain of $B$, $D_B$, is a subset of the domain of $A$, then $T_{BA}(\vec i)=\vec i$ is a one-to-one affine mapping.  We define <code>array-extract</code> to define this common operation; it's like looking at a rectangular sub-part of a spreadsheet. We use it to extract the common part of overlapping domains of three arrays in an image processing example below. </li>
       <li><b>Tiling an array: </b>For various reasons (parallel processing, optimizing cache localization, GPU programming, etc.) one may wish to process a large array as a number of subarrays of the same dimensions, which we call <i>tiling</i> the array.  The routine <code>array-tile</code> returns a new array, each entry of which is a subarray extracted (in the sense of <code>array-extract</code>) from the input array.</li>
       <li><b>Translating the domain of an array: </b>If $\vec d$ is a vector of integers, then $T_{BA}(\vec i)=\vec i-\vec d$ is a one-to-one affine map of $D_B=\{\vec i+\vec d\mid \vec i\in D_A\}$ onto $D_A$. We call $D_B$ the <i>translate</i> of $D_A$, and we define <code>array-translate</code> to provide this operation.</li>
-      <li><b>Permuting the coordinates of an array: </b>If $\pi$ <a href="https://en.wikipedia.org/wiki/Permutation">permutes</a> the coordinates of a multi-index $\vec i$, and $\pi^{-1}$ is the inverse of $\pi$, then $T_{BA}(\vec i)=\pi (\vec i)$ is a one-to-one affine map from $D_B=\{\pi^{-1}(\vec i)\mid \vec i\in D_A\}$ onto $D_A$.  We provide <code>array-permute</code> for this operation. (The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) We also provide <code>array-rotate</code> for the special permutations that just rotate the axes.</li>
+      <li><b>Permuting the coordinates of an array: </b>If $\pi$ <a href="https://en.wikipedia.org/wiki/Permutation">permutes</a> the coordinates of a multi-index $\vec i$, and $\pi^{-1}$ is the inverse of $\pi$, then $T_{BA}(\vec i)=\pi (\vec i)$ is a one-to-one affine map from $D_B=\{\pi^{-1}(\vec i)\mid \vec i\in D_A\}$ onto $D_A$.  We provide <code>array-permute</code> for this operation. (The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) We also provide <code>array-rotate</code> for the special permutations that rotate the axes. For example, in three dimensions we have the following three rotations: $i\ j\ k\to j\ k\ i$; $i\ j\ k\to k\ i\ j$; and the trivial (identity) rotation $i\ j\ k\to i\ j\ k$.</li>
       <li><b>Currying an array: </b>Let's denote the cross product of two intervals $\text{Int}_1$ and $\text{Int}_2$ by $\text{Int}_1\times\text{Int}_2$; if $\vec j=(j_0,\ldots,j_{r-1})\in \text{Int}_1$ and $\vec i=(i_0,\ldots,i_{s-1})\in \text{Int}_2$, then $\vec j\times\vec i$, which we define to be $(j_0,\ldots,j_{r-1},i_0,\ldots,i_{s-1})$, is in $\text{Int}_1\times\text{Int}_2$. If $D_A=\text{Int}_1\times\text{Int}_2$ and $\vec j\in\text{Int}_1$, then $T_{BA}(\vec i)=\vec j\times\vec i$ is a one-to-one affine mapping from $D_B=\text{Int}_2$ into $D_A$.  For each vector $\vec j$ we can compute a new array in this way; we provide <code>array-curry</code> for this operation, which returns an array whose domain is $\text{Int}_1$ and whose elements are themselves arrays, each of which is defined on $\text{Int}_2$. Currying a two-dimensional array would be like organizing a spreadsheet into a one-dimensional array of rows of the spreadsheet.</li>
       <li><b>Traversing some indices in a multi-index in reverse order: </b>Consider an array $A$ with domain $D_A=[l_0,u_0)\times\cdots\times[l_{d-1},u_{d-1})$. Fix $D_B=D_A$ and assume we're given a vector of booleans $F$ ($F$ for &quot;flip?&quot;). Then define $T_{BA}:D_B\to D_A$ by $i_j\to i_j$ if $F_j$ is <code>#f</code> and $i_j\to u_j+l_j-1-i_j$ if  $F_j$ is <code>#t</code>. In other words,  we reverse the ordering of the $j$th coordinate of $\vec i$ if and only if $F_j$ is true. $T_{BA}$ is an affine mapping from $D_B\to D_A$, which defines a new array $B$, and we can provide <code>array-reverse</code> for this operation. Applying <code>array-reverse</code> to a two-dimensional spreadsheet might reverse the order of the rows or columns (or both).</li>
       <li><b>Uniformly sampling an array: </b>Assume that $A$ is an array with domain $[0,u_1)\times\cdots\times[0,u_{d-1})$ (i.e., an interval all of whose lower bounds are zero). We'll also assume the existence of vector $S$ of scale factors, which are positive exact integers. Let $D_B$ be a new interval with $j$th lower bound equal to zero and $j$th upper bound equal to $\operatorname{ceiling}(u_j/S_j)$ and let $T_{BA}(\vec i)_j=i_j\times S_j$, i.e., the $j$th coordinate is scaled by $S_j$.  ($D_B$ contains precisely those multi-indices that $T_{BA}$ maps into $D_A$.) Then $T_{BA}$ is an affine one-to-one mapping, and we provide <code>interval-scale</code> and <code>array-sample</code> for these operations.</li></ul>
@@ -120,6 +121,7 @@
         <a href="#interval-intersect">interval-intersect</a>,
         <a href="#interval-translate">interval-translate</a>,
         <a href="#interval-permute">interval-permute</a>,
+        <a href="#interval-rotate">interval-rotate</a>,
         <a href="#interval-scale">interval-scale</a>,
         <a href="#interval-cartesian-product">interval-cartesian-product</a>.</dd>
       <dt>Storage Classes</dt>
@@ -357,6 +359,9 @@
     <p>For example, if the argument interval represents $[0,4)\times[0,8)\times[0,21)\times [0,16)$ and the
       permutation is <code>#(3 0 1 2)</code>, then the result of <code>(interval-permute <var>interval</var> <var>permutation</var>)</code> will be
       the representation of $[0,16)\times [0,4)\times[0,8)\times[0,21)$.</p>
+    <p><b>Procedure: </b><code><a name="interval-rotate">interval-rotate</a> <var>interval</var> <var>dim</var></code></p>
+    <p>Informally, <code>(interval-rotate <var>interval</var> <var>dim</var>)</code> rotates the axes of <code><var>interval</var></code> <code><var>dim</var></code> places to the left.</p>
+    <p>More precisely, <code>(interval-rotate <var>interval</var> <var>dim</var>)</code> assumes that <code><var>interval</var></code> is an interval and <code><var>dim</var></code> is an exact integer between 0 (inclusive) and <code>(interval-dimension <var>interval</var>)</code> (exclusive).  It computes the permutation <code>(vector <var>dim</var> ... (- (interval-dimension <var>interval</var>) 1) 0 ... (- <var>dim</var> 1))</code> (unless <code><var>dim</var></code> is zero, in which case it constructs the identity permutation) and returns <code>(interval-permute <var>interval</var> <var>permutation</var>)</code>. It is an error if the arguments do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="interval-scale">interval-scale</a> <var>interval</var> <var>scales</var></code></p>
     <p>If <code><var>interval</var></code> is a $d$-dimensional interval $[0,u_1)\times\cdots\times[0,u_{d-1})$ with all lower bounds zero, and <code><var>scales</var></code> is a length-$d$ vector of positive exact integers, which we'll denote by $\vec s$, then <code>interval-scale</code> returns the interval $[0,\operatorname{ceiling}(u_1/s_1))\times\cdots\times[0,\operatorname{ceiling}(u_{d-1}/s_{d-1})$.</p>
     <p>It is an error if  <code><var>interval</var></code> and <code><var>scales</var></code> do not satisfy this condition.</p>
@@ -1512,36 +1517,18 @@ Second-differences in the direction $k\times (1,-1)$:
 
 </pre>
     <p>You can see that with differences in the direction of only the first coordinate, the domains of the difference arrays get smaller in the first coordinate while staying the same in the second coordinate, and with differences in the diagonal directions, the domains of the difference arrays get smaller in both coordinates.</p>
-    <p><b>Separable operators. </b>Many multi-dimensional transforms in signal processing are <i>separable</i>, in that that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the <a href="https://arxiv.org/abs/1210.1944">Fast Hyperbolic Wavelet Transform</a>.  Each one-dimensional subdomain of the complete domain is called a <i>pencil</i>, and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can compute the multidimensional transform as follows:</p>
+    <p><b>Separable operators. </b>Many multi-dimensional transforms in signal processing are <i>separable</i>, in that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the <a href="https://arxiv.org/abs/1210.1944">Fast Hyperbolic Wavelet Transform</a>.  Each one-dimensional subdomain of the complete domain is called a <i>pencil</i>, and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can define the multidimensional transform as follows:</p>
     <pre><code>
 (define (make-separable-transform 1D-transform)
   (lambda (a)
-    (let* ((n
-	    (array-dimension a))
-	   (permutation
-	    ;; we start with the identity permutation
-	    (let ((result (make-vector n)))
-	      (do ((i 0 (fx+ i 1)))
-		  ((fx= i n) result)
-		(vector-set! result i i)))))
-      ;; We apply the one-dimensional transform to all pencils
-      ;; in each coordinate direction.
+    (let ((n (array-dimension a)))
       (do ((d 0 (fx+ d 1)))
-	  ((fx= d n))
-	;; Swap the d'th and n-1'st coordinates
-	(vector-set! permutation (fx- n 1) d)
-	(vector-set! permutation d (fx- n 1))
-	;; array-permute re-orders the coordinates to put the
-	;; d'th coordinate at the end, array-curry returns
-	;; an $n-1$-dimensional array of one-dimensional subarrays,
-	;; and 1D-transform is applied to each of those
-	;; one-dimensional sub-arrays.
-	(array-for-each 1D-transform
-			(array-curry (array-permute a permutation) 1))
-	;; return the permutation to the identity
-	(vector-set! permutation d d)
-	(vector-set! permutation (fx- n 1) (fx- n 1))))))
+          ((fx= d n))
+        (array-for-each
+         1D-transform
+         (array-curry (array-rotate a d) 1))))))
 </code></pre>
+    <p>Here we have cycled through all rotations, putting each axis in turn at the end, and then applied <code>1D-transform</code> to each of the pencils along that axis.</p>
     <p>Wavelet transforms in particular are calculated by recursively applying a transform to an array and then downsampling the array; the inverse transform recursively downsamples and then applies a transform.  So we define the following primitives: </p>
     <pre><code>
 (define (recursively-apply-transform-and-downsample transform)
@@ -1762,7 +1749,9 @@ Reconstructed image:
          (array-map -
                     subarray
                     (array-outer-product * column row)))))))
-
+</code></pre>
+    <p>We then define a $4\times 4$ <a href="https://en.wikipedia.org/wiki/Hilbert_matrix">Hilbert matrix</a>:</p>
+    <pre><code>
 (define A
   (array-&gt;specialized-array
    (make-array (make-interval '#(0 0)
@@ -1855,7 +1844,7 @@ Reconstructed image:
   (let ((a-rows
          (array-curry a 1))
         (b-columns
-         (array-curry (array-permute b '#(1 0)) 1)))
+         (array-curry (array-rotate b 1) 1)))
     (array-outer-product dot-product a-rows b-columns)))
 
 ;;; We'll check that the product of the result of LU
@@ -1885,7 +1874,7 @@ Reconstructed image:
       <li><a name="SRFI-63" href="https://srfi.schemers.org/srfi-63/">SRFI 63: Homogeneous and Heterogeneous Arrays</a>, by Aubrey Jaffer.</li>
       <li><a name="SRFI-164" href="https://srfi.schemers.org/srfi-164/">SRFI 164: Enhanced multi-dimensional Arrays</a>, by Per Bothner.</li></ol>
     <h2>Copyright</h2>
-    <p>&copy; 2016, 2018 Bradley J Lucier. All Rights Reserved.</p>
+    <p>&copy; 2016, 2018, 2020 Bradley J Lucier. All Rights Reserved.</p>
     <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: </p>
     <p>The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.</p>
     <p> THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/srfi-179.scm
+++ b/srfi-179.scm
@@ -61,8 +61,9 @@ MathJax.Hub.Config({
 	     (<a> href: "https://srfi-email.schemers.org/srfi-179" "archive")".  There is a "(<a> href: "https://github.com/scheme-requests-for-implementation/srfi-179"  "git repository")" of this document, a reference implementation, a test file, and other materials.")
 	(<ul> (<li> "Received: 2020/1/11")
               (<li> "60-day deadline: 2020/3/13")
-              (<li> "Draft #1 published: 2020/1/11")
-              (<li> "Draft #2 published: 2020/1/27"))
+              (<li> "Draft #1 published: 2020/01/11")
+              (<li> "Draft #2 published: 2020/01/27")
+              (<li> "Draft #3 published: 2020/02/04"))
 
 	(<h2> "Abstract")
 	(<p>
@@ -85,7 +86,7 @@ MathJax.Hub.Config({
          )
          (<p> "This SRFI differs from the finalized " (<a> href: "https://srfi.schemers.org/srfi-122/" "SRFI-122")" in the following ways:")
         (<ul>
-         (<li> "The procedures "(<code>'interval-for-each)", "(<code>'interval-cartesian-product)", "(<code>'array-outer-product)", "(<code>'array-tile)", "(<code>'array-rotate)", "(<code>'array-reduce)", "(<code>'array-assign!)", and "(<code>'array-swap!)" have been added together with some examples.")
+         (<li> "The procedures "(<code>'interval-for-each)", "(<code>'interval-cartesian-product)", "(<code>'interval-rotate)", "(<code>'array-outer-product)", "(<code>'array-tile)", "(<code>'array-rotate)", "(<code>'array-reduce)", "(<code>'array-assign!)", and "(<code>'array-swap!)" have been added together with some examples.")
          (<li> "The discussion of Haar transforms as examples of separable transforms has been corrected.")
          (<li> "The documentation has a few more examples of image processing algorithms.")
          (<li> "Some matrix examples have been added to this document."))
@@ -145,7 +146,7 @@ MathJax.Hub.Config({
 	       "If $\\pi$ "(<a> href: "https://en.wikipedia.org/wiki/Permutation" 'permutes)" the coordinates of a multi-index $\\vec i$, and $\\pi^{-1}$ is the inverse of $\\pi$, then "
 	       "$T_{BA}(\\vec i)=\\pi (\\vec i)$ is a one-to-one affine map from $D_B=\\{\\pi^{-1}(\\vec i)\\mid \\vec i\\in D_A\\}$ onto $D_A$.  We provide "(<code>'array-permute)" for this operation. "
 	       "(The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) "
-               "We also provide "(<code>'array-rotate)" for the special permutations that just rotate the axes.")
+               "We also provide "(<code>'array-rotate)" for the special permutations that rotate the axes. For example, in three dimensions we have the following three rotations: $i\\ j\\ k\\to j\\ k\\ i$; $i\\ j\\ k\\to k\\ i\\ j$; and the trivial (identity) rotation $i\\ j\\ k\\to i\\ j\\ k$.")
 	 (<li> (<b> "Currying an array: ")
 	       "Let's denote the cross product of two intervals $\\text{Int}_1$ and $\\text{Int}_2$ by $\\text{Int}_1\\times\\text{Int}_2$; "
 	       "if $\\vec j=(j_0,\\ldots,j_{r-1})\\in \\text{Int}_1$ and $\\vec i=(i_0,\\ldots,i_{s-1})\\in \\text{Int}_2$, then "
@@ -256,6 +257,7 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#interval-intersect" "interval-intersect")END
                  (<a> href: "#interval-translate" "interval-translate")END
                  (<a> href: "#interval-permute" "interval-permute") END
+                 (<a> href: "#interval-rotate" "interval-rotate") END
                  (<a> href: "#interval-scale" "interval-scale") END
                  (<a> href: "#interval-cartesian-product" "interval-cartesian-product")
                  ".")
@@ -540,6 +542,11 @@ $[l_{\\pi_0},u_{\\pi_0})\\times[l_{\\pi_1},u_{\\pi_1})\\times\\cdots\\times[l_{\
 (<p> "For example, if the argument interval represents $[0,4)\\times[0,8)\\times[0,21)\\times [0,16)$ and the
 permutation is "(<code>'#(3 0 1 2))", then the result of "(<code> "(interval-permute "(<var>'interval)" "(<var>' permutation)")")" will be
 the representation of $[0,16)\\times [0,4)\\times[0,8)\\times[0,21)$.")
+
+(format-lambda-list '(interval-rotate interval dim))
+(<p> "Informally, "(<code> "(interval-rotate "(<var>'interval)" "(<var>'dim)")")" rotates the axes of "(<code>(<var>'interval))" "(<code>(<var>'dim))" places to the left.")
+(<p> "More precisely, "(<code> "(interval-rotate "(<var>'interval)" "(<var> 'dim)")")" assumes that "(<code>(<var>'interval))" is an interval and "(<code>(<var>'dim))" is an exact integer between 0 (inclusive) and "(<code> "(interval-dimension "(<var>'interval)")")" (exclusive).  It computes the permutation "(<code>"(vector "(<var>'dim)" ... (- (interval-dimension "(<var>'interval)") 1) 0 ... (- "(<var>'dim)" 1))")" (unless "(<code>(<var>'dim))" is zero, in which case it constructs the identity permutation) and returns "(<code>"(interval-permute "(<var>'interval)" "(<var>'permutation)")")". It is an error if the arguments do not satisfy these conditions.")
+
 
 (format-lambda-list '(interval-scale interval scales))
 (<p> "If "(<code>(<var>'interval))" is a $d$-dimensional interval $[0,u_1)\\times\\cdots\\times[0,u_{d-1})$ with all lower bounds zero, "
@@ -1881,36 +1888,18 @@ Second-differences in the direction $k\\times (1,-1)$:
 
 
 
-(<p> (<b> "Separable operators. ")"Many multi-dimensional transforms in signal processing are "(<i> 'separable)", in that that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the "(<a> href: "https://arxiv.org/abs/1210.1944" "Fast Hyperbolic Wavelet Transform")".  Each one-dimensional subdomain of the complete domain is called a "(<i> 'pencil)", and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can compute the multidimensional transform as follows:")
+(<p> (<b> "Separable operators. ")"Many multi-dimensional transforms in signal processing are "(<i> 'separable)", in that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the "(<a> href: "https://arxiv.org/abs/1210.1944" "Fast Hyperbolic Wavelet Transform")".  Each one-dimensional subdomain of the complete domain is called a "(<i> 'pencil)", and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can define the multidimensional transform as follows:")
 (<pre> (<code>"
 (define (make-separable-transform 1D-transform)
   (lambda (a)
-    (let* ((n
-	    (array-dimension a))
-	   (permutation
-	    ;; we start with the identity permutation
-	    (let ((result (make-vector n)))
-	      (do ((i 0 (fx+ i 1)))
-		  ((fx= i n) result)
-		(vector-set! result i i)))))
-      ;; We apply the one-dimensional transform to all pencils
-      ;; in each coordinate direction.
+    (let ((n (array-dimension a)))
       (do ((d 0 (fx+ d 1)))
-	  ((fx= d n))
-	;; Swap the d'th and n-1'st coordinates
-	(vector-set! permutation (fx- n 1) d)
-	(vector-set! permutation d (fx- n 1))
-	;; array-permute re-orders the coordinates to put the
-	;; d'th coordinate at the end, array-curry returns
-	;; an $n-1$-dimensional array of one-dimensional subarrays,
-	;; and 1D-transform is applied to each of those
-	;; one-dimensional sub-arrays.
-	(array-for-each 1D-transform
-			(array-curry (array-permute a permutation) 1))
-	;; return the permutation to the identity
-	(vector-set! permutation d d)
-	(vector-set! permutation (fx- n 1) (fx- n 1))))))
+          ((fx= d n))
+        (array-for-each
+         1D-transform
+         (array-curry (array-rotate a d) 1))))))
 "))
+(<p> "Here we have cycled through all rotations, putting each axis in turn at the end, and then applied "(<code>'1D-transform)" to each of the pencils along that axis.")
 (<p> "Wavelet transforms in particular are calculated by recursively applying a transform to an array and then downsampling the array; the inverse transform recursively downsamples and then applies a transform.  So we define the following primitives: ")
 (<pre>(<code>"
 (define (recursively-apply-transform-and-downsample transform)
@@ -2134,7 +2123,10 @@ The code uses "(<code>'array-assign!)", "(<code>'specialized-array-share)", "(<c
          (array-map -
                     subarray
                     (array-outer-product * column row)))))))
-
+"))
+(<p> "We then define a $4\\times 4$ "(<a> href: "https://en.wikipedia.org/wiki/Hilbert_matrix" "Hilbert matrix")":")
+(<pre>
+ (<code>"
 (define A
   (array->specialized-array
    (make-array (make-interval '#(0 0)
@@ -2228,7 +2220,7 @@ The code uses "(<code>'array-assign!)", "(<code>'specialized-array-share)", "(<c
   (let ((a-rows
          (array-curry a 1))
         (b-columns
-         (array-curry (array-permute b '#(1 0)) 1)))
+         (array-curry (array-rotate b 1) 1)))
     (array-outer-product dot-product a-rows b-columns)))
 
 ;;; We'll check that the product of the result of LU
@@ -2261,7 +2253,7 @@ The code uses "(<code>'array-assign!)", "(<code>'specialized-array-share)", "(<c
  (<li> (<a> name: 'SRFI-63 href: "https://srfi.schemers.org/srfi-63/" "SRFI 63: Homogeneous and Heterogeneous Arrays")", by Aubrey Jaffer.")
  (<li> (<a> name: 'SRFI-164 href: "https://srfi.schemers.org/srfi-164/" "SRFI 164: Enhanced multi-dimensional Arrays")", by Per Bothner."))
 (<h2> "Copyright")
-(<p> (<unprotected> "&copy;")" 2016, 2018 Bradley J Lucier. All Rights Reserved.")
+(<p> (<unprotected> "&copy;")" 2016, 2018, 2020 Bradley J Lucier. All Rights Reserved.")
 (<p> "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: ")
 (<p> "The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.")
 (<p> " THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/srfi-179.scm
+++ b/srfi-179.scm
@@ -29,10 +29,10 @@
 	(<meta> charset: "utf-8")
         (<meta> name: 'viewport
                 content: "width=device-width, initial-scale=1")
-	(<title> "Nonempty Intervals and Generalized Arrays")
-	(<link> href: "http://srfi.schemers.org/srfi.css"
+	(<title> "Nonempty Intervals and Generalized Arrays (Updated)")
+	(<link> href: "https://srfi.schemers.org/srfi.css"
 		rel: "stylesheet"
-                type: "test/css")
+                type: "text/css")
 	(<script> type: "text/x-mathjax-config" "
 MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]}
@@ -44,22 +44,25 @@ MathJax.Hub.Config({
 	)
        (<body>
 	(<h1> "Title")
-	(<p> "Nonempty Intervals and Generalized Arrays")
+	(<p> "Nonempty Intervals and Generalized Arrays (Updated)")
 
 	(<h2> "Author")
 	(<p> "Bradley J. Lucier")
 
 	(<h2> "Status")
 	(<p> "This SRFI is currently in " (<em> "draft") " status.  Here is "
-	     (<a> href: "http://srfi.schemers.org/srfi-process.html" "an explanation")
+	     (<a> href: "https://srfi.schemers.org/srfi-process.html" "an explanation")
 	     " of each status that a SRFI can hold.  To provide input on this SRFI, please send email to "
-	     (<code> (<a> href: "mailto:srfi minus 179 at srfi dot schemers dot org"
+	     (<code> (<a> href: "mailto:srfi+minus+179+at+srfi+dotschemers+dot+org"
 			  "srfi-179@" (<span> class: "antispam" "nospam") "srfi.schemers.org"))
 	     ".  To subscribe to the list, follow "
-	     (<a> href: "http://srfi.schemers.org/srfi-list-subscribe.html" "these instructions")
+	     (<a> href: "https://srfi.schemers.org/srfi-list-subscribe.html" "these instructions")
 	     ".  You can access previous messages via the mailing list "
-	     (<a> href: "http://srfi-email.schemers.org/srfi-179" "archive")".  There is a "(<a> href: "https://github.com/scheme-requests-for-implementation/srfi-179"  "git repository")" of this document, a reference implementation, a test file, and other materials.")
-	(<ul> (<li> "Received: 2020/1/11"))
+	     (<a> href: "https://srfi-email.schemers.org/srfi-179" "archive")".  There is a "(<a> href: "https://github.com/scheme-requests-for-implementation/srfi-179"  "git repository")" of this document, a reference implementation, a test file, and other materials.")
+	(<ul> (<li> "Received: 2020/1/11")
+              (<li> "60-day deadline: 2020/3/13")
+              (<li> "Draft #1 published: 2020/1/11")
+              (<li> "Draft #2 published: 2020/1/27"))
 
 	(<h2> "Abstract")
 	(<p>
@@ -82,10 +85,10 @@ MathJax.Hub.Config({
          )
          (<p> "This SRFI differs from the finalized " (<a> href: "https://srfi.schemers.org/srfi-122/" "SRFI-122")" in the following ways:")
         (<ul>
-         (<li> "The procedures "(<code>'interval-for-each)", "(<code>'interval-cartesian-product)", "(<code>'array-outer-product)", "(<code>'array-tile)", "(<code>'array-assign!)", and "(<code>'array-swap!)" have been added.")
+         (<li> "The procedures "(<code>'interval-for-each)", "(<code>'interval-cartesian-product)", "(<code>'array-outer-product)", "(<code>'array-tile)", "(<code>'array-rotate)", "(<code>'array-reduce)", "(<code>'array-assign!)", and "(<code>'array-swap!)" have been added together with some examples.")
          (<li> "The discussion of Haar transforms as examples of separable transforms has been corrected.")
          (<li> "The documentation has a few more examples of image processing algorithms.")
-         (<li> "Some matrix examples have been added to this document and test-arrays.scm."))
+         (<li> "Some matrix examples have been added to this document."))
 
 
 	(<h2> "Overview")
@@ -141,7 +144,8 @@ MathJax.Hub.Config({
 	 (<li> (<b> "Permuting the coordinates of an array: ")
 	       "If $\\pi$ "(<a> href: "https://en.wikipedia.org/wiki/Permutation" 'permutes)" the coordinates of a multi-index $\\vec i$, and $\\pi^{-1}$ is the inverse of $\\pi$, then "
 	       "$T_{BA}(\\vec i)=\\pi (\\vec i)$ is a one-to-one affine map from $D_B=\\{\\pi^{-1}(\\vec i)\\mid \\vec i\\in D_A\\}$ onto $D_A$.  We provide "(<code>'array-permute)" for this operation. "
-	       "The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.")
+	       "(The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) "
+               "We also provide "(<code>'array-rotate)" for the special permutations that just rotate the axes.")
 	 (<li> (<b> "Currying an array: ")
 	       "Let's denote the cross product of two intervals $\\text{Int}_1$ and $\\text{Int}_2$ by $\\text{Int}_1\\times\\text{Int}_2$; "
 	       "if $\\vec j=(j_0,\\ldots,j_{r-1})\\in \\text{Int}_1$ and $\\vec i=(i_0,\\ldots,i_{s-1})\\in \\text{Int}_2$, then "
@@ -152,7 +156,7 @@ MathJax.Hub.Config({
 	       "Currying a two-dimensional array would be like organizing a spreadsheet into a one-dimensional array of rows of the spreadsheet.")
 	 (<li> (<b> "Traversing some indices in a multi-index in reverse order: ")
 	       "Consider an array $A$ with domain $D_A=[l_0,u_0)\\times\\cdots\\times[l_{d-1},u_{d-1})$. Fix $D_B=D_A$ and assume we're given a vector of booleans $F$ ($F$ for \"flip?\"). "
-               "Then define $T_{BA}:D_B\\to D_A$ by $i_j\\to i_j$ if $F_j$ is "(<code>'#f)" and $i_j\\to u_j+l_j-1-i_j$ if  $F_j$ is "(<code>'#t)"."
+               "Then define $T_{BA}:D_B\\to D_A$ by $i_j\\to i_j$ if $F_j$ is "(<code>'#f)" and $i_j\\to u_j+l_j-1-i_j$ if  $F_j$ is "(<code>'#t)". "
 	       "In other words,  we reverse the ordering of the $j$th coordinate of $\\vec i$ if and only if $F_j$ is true. "
 	       "$T_{BA}$ is an affine mapping from $D_B\\to D_A$, which defines a new array $B$, and we can provide "(<code>'array-reverse)" for this operation. "
                "Applying "(<code>'array-reverse)" to a two-dimensional spreadsheet might reverse the order of the rows or columns (or both).")
@@ -161,7 +165,7 @@ MathJax.Hub.Config({
                "We'll also assume the existence of vector $S$ of scale factors, which are positive exact integers. "
                "Let $D_B$ be a new interval with $j$th lower bound equal to zero and $j$th upper bound equal to $\\operatorname{ceiling}(u_j/S_j)$ and let "
                "$T_{BA}(\\vec i)_j=i_j\\times S_j$, i.e., the $j$th coordinate is scaled by $S_j$.  ($D_B$ contains precisely those multi-indices that $T_{BA}$ maps into $D_A$.) "
-               " Then $T_{BA}$ is an affine one-to-one mapping, and we provide "(<code>'interval-scale)" and "(<code>'array-sample)" for these operations.")
+               "Then $T_{BA}$ is an affine one-to-one mapping, and we provide "(<code>'interval-scale)" and "(<code>'array-sample)" for these operations.")
          )
 	(<p> "We make several remarks.  First, all these operations could have been computed by specifying the particular mapping $T_{BA}$ explicitly, so that these routines are simply "
 	     "\"convenience\" procedures.  Second, because the composition of any number of affine mappings are again affine, accessing or changing the elements of a "
@@ -192,7 +196,7 @@ they may have hash tables or databases behind an implementation, one may read th
 	     (<code>"(array-getter B)")" is simply "(<code>'A-getter)".  Similarly, if A is a two-dimensional array, and B is derived from A by applying the permutation $\\pi((i,j))=(j,i)$, then "(<code>"(array-getter B)")" is "
 	     (<code>"(lambda (i j) (A-getter j i))")".  Translation and currying also lead to transformed arrays whose getters are relatively efficiently derived from "(<code>'A-getter)", at least for arrays of small dimension.")
 	(<p> "Thus, while we do not provide for sharing of generalized arrays for general one-to-one affine maps $T$, we do allow it for the specific functions "(<code>'array-extract)", "(<code>'array-translate)", "(<code>'array-permute)",  "
-	     (<code>'array-curry)",  "(<code>'array-reverse)", and "(<code>'array-sample)",  and we provide relatively efficient implementations of these functions for arrays of dimension no greater than four.")
+	     (<code>'array-curry)",  "(<code>'array-reverse)", "(<code>'array-tile)", "(<code>'array-rotate)" and "(<code>'array-sample)",  and we provide relatively efficient implementations of these functions for arrays of dimension no greater than four.")
 	(<h3> "Array-map does not produce a specialized array")
 	(<p> "Daniel Friedman and David Wise wrote a famous paper "(<a> href: "http://www.cs.indiana.edu/cgi-bin/techreports/TRNNN.cgi?trnum=TR44" "CONS should not Evaluate its Arguments")". "
 	     "In the spirit of that paper, our procedure "(<code>'array-map)" does not immediately produce a specialized array, but a simple immutable array, whose elements are recomputed from the arguments of "(<code>'array-map)
@@ -209,13 +213,13 @@ they may have hash tables or databases behind an implementation, one may read th
 
         (<h2> "Issues and Notes")
         (<ul>
-         (<li> (<b> "Relationship to "(<a> href: "http://docs.racket-lang.org/math/array_nonstrict.html#%28tech._nonstrict%29" "nonstrict arrays")" in Racket. ")
-               "It appears that what we call simply arrays in this SRFI are called nonstrict arrays in the math/array library of Racket, which in turn was influenced by an "(<a> href: "http://research.microsoft.com/en-us/um/people/simonpj/papers/ndp/RArrays.pdf" "array proposal for Haskell")".  Our \"specialized\" arrays are related to Racket's \"strict\" arrays.")
+         (<li> (<b> "Relationship to "(<a> href: "https://docs.racket-lang.org/math/array_nonstrict.html#%28tech._nonstrict%29" "nonstrict arrays")" in Racket. ")
+               "It appears that what we call simply arrays in this SRFI are called nonstrict arrays in the math/array library of Racket, which in turn was influenced by an "(<a> href: "https://research.microsoft.com/en-us/um/people/simonpj/papers/ndp/RArrays.pdf" "array proposal for Haskell")".  Our \"specialized\" arrays are related to Racket's \"strict\" arrays.")
          (<li> (<b> "Indexers. ")"The argument new-domain->old-domain to "(<code> 'specialized-array-share)" is, conceptually, a multi-valued array.")
-         (<li> (<b> "Source of function names. ")"The function "(<code> 'array-curry)" gets its name from the " #\newline
-               (<a> href: "http://en.wikipedia.org/wiki/Currying" "curry operator")
-               " in programming---we are currying the getter of the array and keeping careful track of the domains. " #\newline
-               (<code>'interval-projections)" can be thought of as currying the " #\newline
+         (<li> (<b> "Source of function names. ")"The function "(<code> 'array-curry)" gets its name from the" #\newline
+               (<a> href: "https://en.wikipedia.org/wiki/Currying" "curry operator")
+               " in programming---we are currying the getter of the array and keeping careful track of the domains." #\newline
+               (<code>'interval-projections)" can be thought of as currying the" #\newline
                "characteristic function of the interval,  encapsulated here as "(<code> 'interval-contains-multi-index?)".")
          (<li> (<b> "Choice of functions on intervals. ")"The choice of functions for both arrays and intervals was motivated almost solely by what I needed for arrays.")
          (<li> (<b> "No empty intervals. ")"This SRFI considers arrays over only nonempty intervals of positive dimension.  The author of this proposal acknowledges that other languages and array systems allow either zero-dimensional intervals or empty intervals of positive dimension, but prefers to leave such empty intervals as possibly compatible extensions to the current proposal.")
@@ -301,6 +305,7 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#array-tile" "array-tile") END
                  (<a> href: "#array-translate" "array-translate")END
                  (<a> href: "#array-permute" "array-permute")END
+                 (<a> href: "#array-rotate" "array-rotate")END
                  (<a> href: "#array-reverse" "array-reverse")END
                  (<a> href: "#array-sample" "array-sample")END
                  (<a> href: "#array-outer-product" "array-outer-product") END
@@ -308,6 +313,7 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#array-for-each" "array-for-each")END
                  (<a> href: "#array-fold" "array-fold")END
                  (<a> href: "#array-fold-right" "array-fold-right")END
+                 (<a> href: "#array-reduce" "array-reduce") END
                  (<a> href: "#array-any" "array-any")END
                  (<a> href: "#array-every" "array-every")END
                  (<a> href: "#array->list" "array->list") END
@@ -1126,9 +1132,12 @@ a mutable-array, then "(<code>'array-permute)" returns the new mutable")
                      ("(<unprotected> "&pi;")(<sup>"-1")" multi-index))))"))
 (<p>"It is an error to call "(<code>'array-permute)" if its arguments do not satisfy these conditions.")
 
+(format-lambda-list '(array-rotate array dim))
+(<p> "Informally, "(<code> "(array-rotate "(<var>'array)" "(<var>'dim)")")" rotates the axes of "(<code>(<var>'array))" "(<code>(<var>'dim))" places to the left.")
+(<p> "More precisely, "(<code> "(array-rotate "(<var>'array)" "(<var> 'dim)")")" assumes that "(<code>(<var>'array))" is an array and "(<code>(<var>'dim))" is an exact integer between 0 (inclusive) and "(<code> "(array-dimension "(<var>'array)")")" (exclusive).  It computes the permutation "(<code>"(vector "(<var>'dim)" ... (- (array-dimension "(<var>'array)") 1) 0 ... (- "(<var>'dim)" 1))")" (unless "(<code>(<var>'dim))" is zero, in which case it constructs the identity permutation) and returns "(<code>"(array-permute "(<var>'array)" "(<var>'permutation)")")". It is an error if the arguments do not satisfy these conditions.")
 
-(format-lambda-list '(array-reverse array flip?))
-(<p> "We assume that "(<code>(<var>'array))" is an array and "(<code>(<var>'flip?))" is a vector of booleans whose length is the same as the dimension of "(<code>(<var>'array))".")
+(format-lambda-list '(array-reverse array #!optional flip?))
+(<p> "We assume that "(<code>(<var>'array))" is an array and "(<code>(<var>'flip?))", if given, is a vector of booleans whose length is the same as the dimension of "(<code>(<var>'array))".  If "(<code>(<var>'flip?))" is not given, it is set to a vector with length the same as the dimension of "(<code>(<var>'array))", all of whose elements are "(<code> "#t")".")
 (<p> (<code>'array-reverse)" returns a new array  that is specialized,  mutable, or immutable according to whether "(<code>(<var>'array))" is specialized, mutable, or immutable, respectively.  Informally, if "(<code>"(vector-ref "(<var>'flip?)" k)")" is true, then the ordering of multi-indices in the k'th coordinate direction is reversed, and is left undisturbed otherwise.")
 (<p> "More formally, we introduce the function ")
 (<pre>
@@ -1176,6 +1185,42 @@ a mutable-array, then "(<code>'array-permute)" returns the new mutable")
    (apply (array-getter "(<code>(<var>'array))")
           (flip-multi-index multi-index))))) "))
 (<p> "It is an error if "(<code>(<var>'array))" and "(<code>(<var>'flip?))" don't satisfy these requirements.")
+(<p> "The following example using "(<code>'array-reverse)" was motivated by "(<a> href: "https://funcall.blogspot.com/2020/01/palindromes-redux-and-sufficiently.html" "a blog post by Joe Marshall")".")
+(<pre>
+ (<code>"
+(define (palindrome? s)
+  (let ((n (string-length s)))
+    (or (< n 2)
+        (let* ((a
+                ;; an array accessing the characters of s
+                (make-array (make-interval '#(0)
+                                           (vector n))
+                            (lambda (i)
+                              (string-ref s i))))
+               (ra
+                ;; the array accessed in reverse order
+                (array-reverse a))
+               (half-domain
+                (make-interval '#(0)
+                               (vector (quotient n 2)))))
+          (array-every
+           char=?
+           ;; the first half of s
+           (array-extract a half-domain)
+           ;; the reversed second half of s
+           (array-extract ra half-domain))))))
+
+(palindrome? \"\") => #t
+(palindrome? \"a\") => #t
+(palindrome? \"aa\") => #t
+(palindrome? \"ab\") => #f
+(palindrome? \"aba\") => #t
+(palindrome? \"abc\") => #f
+(palindrome? \"abba\") => #t
+(palindrome? \"abca\") => #f
+(palindrome? \"abbc\") => #f
+"))
+
 
 (format-lambda-list '(array-sample array scales))
 (<p> "We assume that "(<code>(<var>'array))" is an array all of whose lower bounds are zero, "
@@ -1331,6 +1376,58 @@ calls")
  (<code>"
 (fold-right "(<var>'kons)" " (<var>'knil)" (array->list "(<var> 'array)"))"))
 (<p> "It is an error if "(<code>(<var>'array))" is not an array, or if "(<code>(<var>'kons))" is not a procedure.")
+
+(format-lambda-list '(array-reduce op A))
+
+(<p> "We assume that "(<code>(<var>'A))" is an array and "(<code>(<var>'op))" is a procedure of two arguments that is associative, i.e., "(<code>"("(<var>'op)" ("(<var>'op)" "(<var>'x)" "(<var>'y)") "(<var>'z)")")" is the same as "(<code>"("(<var>'op)" "(<var>'x)" ("(<var>'op)"  "(<var>'y)" "(<var>'z)"))")".")
+(<p> "Then "(<code>"(array-reduce "(<var>'op)" "(<var>'A)")")" returns")
+(<pre>
+ (<code>"
+(let ((box '())
+      (A_ (array-getter A)))
+  (interval-for-each
+   (lambda args
+     (if (null? box)
+         (set! box (list (apply A_ args)))
+         (set-car! box (op (car box)
+                           (apply A_ args)))))
+   (array-domain A))
+  (car box))
+"))
+(<p> "The implementation is allowed to use the associativity of "(<code>(<var>'op))" to reorder the computations in "(<code>'array-reduce)". It is an error if the arguments do not satisfy these conditions.")
+(<p> "As an example, we consider the finite sum:
+$$
+S_m=\\sum_{k=1}^m \\frac 1{k^2}.
+$$
+One can show that
+$$
+\\frac 1 {m+1}<\\frac{\\pi^2}6-S_m<\\frac 1m.
+$$
+We attempt to compute this in floating-point arithmetic in two ways. In the first, we apply "
+     (<code>'array-reduce)" to an array containing the terms of the series, basically a serial computation.  In the second, we divide the series into blocks of no more than 1,000 consecutive terms, apply "
+     (<code>'array-reduce)" to get a new sequence of terms, and repeat the process. The second way is approximately what might happen with GPU computing.")
+(<p> " We find with $m=1{,}000{,}000{,}000$: ")
+(<pre>
+ (<code>"
+(define A (make-array (make-interval '#(1) '#(1000000001))
+                      (lambda (k)
+                        (fl/ (flsquare (inexact k))))))
+(define (block-sum A)
+  (let ((N (interval-volume (array-domain A))))
+    (cond ((<= N 1000)
+           (array-reduce fl+ A))
+          ((<= N (square 1000))
+           (block-sum (array-map block-sum
+                                 (array-tile A (vector (integer-sqrt N))))))
+          (else
+           (block-sum (array-map block-sum
+                                 (array-tile A (vector (quotient N 1000)))))))))
+(array-reduce fl+ A) => 1.644934057834575
+(block-sum A)        => 1.6449340658482325
+"))
+(<p> "Since $\\pi^2/6\\approx{}$"(<code>"1.6449340668482264")", we see  using the first method that the difference $\\pi^2/6-{}$"(<code>"1.644934057834575")"${}\\approx{}$"(<code>"9.013651380840315e-9")" and with the second we have "
+     "$\\pi^2/6-{}$"(<code>"1.6449340658482325")"${}\\approx{}$"(<code>"9.99993865491433e-10")".  The true difference should be between $\\frac 1{1{,}000{,}000{,}001}\\approx{}$"(<code>"9.99999999e-10")" and $\\frac 1{1{,}000{,}000{,}000}={}$"(<code>"1e-9")". The difference for the first method is about 10 times too big, and, in fact, will not change further because any futher terms, when added to the partial sum, are too small to increase the sum after rounding-to-nearest in double-precision IEEE-754 floating-point arithmetic.")
+
 
 (format-lambda-list '(array-any pred array1 array2 "..."))
 
@@ -1667,7 +1764,7 @@ order in array->specialized-array guarantees the the correct order of execution 
 
 (<p> (<b> "Calculating second differences of images. ")"For another example, if a real-valued function is defined
 on a two-dimensional interval $I$, its second difference in the direction $d$ at the point $x$ is defined as $\\Delta^2_df(x)=f(x+2d)-2f(x+d)+f(x)$,
-and this function is defined only for those $x$ for which $x$, $x+d$, and $x+2d$ are all in $I$. See the beginning of the section on \"Moduli of smoothness\" in "(<a> href: "http://www.math.purdue.edu/~lucier/692/related_papers_summaries.html#Wavelets-and-approximation-theory" "these notes on wavelets and approximation theory")" for more details.")
+and this function is defined only for those $x$ for which $x$, $x+d$, and $x+2d$ are all in $I$. See the beginning of the section on \"Moduli of smoothness\" in "(<a> href: "https://www.math.purdue.edu/~lucier/692/related_papers_summaries.html#Wavelets-and-approximation-theory" "these notes on wavelets and approximation theory")" for more details.")
 (<p> "Using this definition, the following code computes all second-order forward differences of an image in the directions
 $d,2 d,3 d,\\ldots$, defined only on the domains where this makes sense: ")
 (<pre>
@@ -1882,7 +1979,7 @@ Second-differences in the direction $k\\times (1,-1)$:
                         ((0) 1.)
                         ((1) -1.)
                         (else 0.)))))))
-  (display \"\nInitial image: \n\")
+  (display \"\nInitial image:\n\")
   (pretty-print (list (array-domain image)
 		      (array->list image)))
   (hyperbolic-Haar-transform image)
@@ -1935,7 +2032,7 @@ Reconstructed image:
                         ((0) 1.)
                         ((1) -1.)
                         (else 0.)))))))
-  (display \"\\nInitial image: \\n\")
+  (display \"\\nInitial image:\\n\")
   (pretty-print (list (array-domain image)
 		      (array->list image)))
   (Haar-transform image)
@@ -2155,13 +2252,14 @@ The code uses "(<code>'array-assign!)", "(<code>'specialized-array-share)", "(<c
 (<p> "The SRFI author thanks Edinah K Gnang, John Cowan, Sudarshan S Chawathe, Jamison Hope, and Per Bothner for their comments and suggestions, and Arthur A Gleckler, SRFI Editor, for his guidance and patience.")
 (<h2> "References")
 (<ol>
- (<li> (<a> name: 'bawden href: "http://groups-beta.google.com/group/comp.lang.scheme/msg/6c2f85dbb15d986b?hl=en&" "\"multi-dimensional arrays in R5RS?\"")
+ (<li> (<a> name: 'bawden href: "https://groups-beta.google.com/group/comp.lang.scheme/msg/6c2f85dbb15d986b?hl=en&" "\"multi-dimensional arrays in R5RS?\"")
        ", by Alan Bawden.")
- (<li> (<a> name: 'SRFI-4  href: "http://srfi.schemers.org/srfi-4/"  "SRFI 4:  Homogeneous Numeric Vector Datatypes")", by Marc Feeley.")
- (<li> (<a> name: 'SRFI-25 href: "http://srfi.schemers.org/srfi-25/" "SRFI 25: Multi-dimensional Array Primitives")", by Jussi Piitulainen.")
- (<li> (<a> name: 'SRFI-47 href: "http://srfi.schemers.org/srfi-47/" "SRFI 47: Array")", by Aubrey Jaffer.")
- (<li> (<a> name: 'SRFI-58 href: "http://srfi.schemers.org/srfi-58/" "SRFI 58: Array Notation")", by Aubrey Jaffer.")
- (<li> (<a> name: 'SRFI-63 href: "http://srfi.schemers.org/srfi-63/" "SRFI 63: Homogeneous and Heterogeneous Arrays")", by Aubrey Jaffer."))
+ (<li> (<a> name: 'SRFI-4  href: "https://srfi.schemers.org/srfi-4/"  "SRFI 4:  Homogeneous Numeric Vector Datatypes")", by Marc Feeley.")
+ (<li> (<a> name: 'SRFI-25 href: "https://srfi.schemers.org/srfi-25/" "SRFI 25: Multi-dimensional Array Primitives")", by Jussi Piitulainen.")
+ (<li> (<a> name: 'SRFI-47 href: "https://srfi.schemers.org/srfi-47/" "SRFI 47: Array")", by Aubrey Jaffer.")
+ (<li> (<a> name: 'SRFI-58 href: "https://srfi.schemers.org/srfi-58/" "SRFI 58: Array Notation")", by Aubrey Jaffer.")
+ (<li> (<a> name: 'SRFI-63 href: "https://srfi.schemers.org/srfi-63/" "SRFI 63: Homogeneous and Heterogeneous Arrays")", by Aubrey Jaffer.")
+ (<li> (<a> name: 'SRFI-164 href: "https://srfi.schemers.org/srfi-164/" "SRFI 164: Enhanced multi-dimensional Arrays")", by Per Bothner."))
 (<h2> "Copyright")
 (<p> (<unprotected> "&copy;")" 2016, 2018 Bradley J Lucier. All Rights Reserved.")
 (<p> "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: ")

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -97,7 +97,7 @@
 (pp "interval-dimension error tests")
 
 (test (interval-dimension 1)
-      "interval-dimension: argument is not an interval: ")
+      "interval-dimension: The argument is not an interval: ")
 
 (pp "interval-dimension result tests")
 
@@ -107,52 +107,52 @@
 (pp "interval-lower-bound error tests")
 
 (test (interval-lower-bound 1 0)
-      "interval-lower-bound: argument is not an interval: ")
+      "interval-lower-bound: The first argument is not an interval: ")
 
 (test (interval-lower-bound (make-interval '#(1 2 3) '#(4 5 6)) #f)
-      "interval-lower-bound: argument is not an exact integer: ")
+      "interval-lower-bound: The second argument is not an exact integer: ")
 
 (test (interval-lower-bound (make-interval '#(1 2 3) '#(4 5 6)) 1.)
-      "interval-lower-bound: argument is not an exact integer: ")
+      "interval-lower-bound: The second argument is not an exact integer: ")
 
 (test (interval-lower-bound (make-interval '#(1 2 3) '#(4 5 6)) -1)
-      "interval-lower-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
+      "interval-lower-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
 
 (test (interval-lower-bound (make-interval '#(1 2 3) '#(4 5 6)) 3)
-      "interval-lower-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
+      "interval-lower-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
 
 (test (interval-lower-bound (make-interval '#(1 2 3) '#(4 5 6)) 4)
-      "interval-lower-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
+      "interval-lower-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
 
 (pp "interval-upper-bound error tests")
 
 (test (interval-upper-bound 1 0)
-      "interval-upper-bound: argument is not an interval: ")
+      "interval-upper-bound: The first argument is not an interval: ")
 
 (test (interval-upper-bound (make-interval '#(1 2 3) '#(4 5 6)) #f)
-      "interval-upper-bound: argument is not an exact integer: ")
+      "interval-upper-bound: The second argument is not an exact integer: ")
 
 (test (interval-upper-bound (make-interval '#(1 2 3) '#(4 5 6)) 1.)
-      "interval-upper-bound: argument is not an exact integer: ")
+      "interval-upper-bound: The second argument is not an exact integer: ")
 
 (test (interval-upper-bound (make-interval '#(1 2 3) '#(4 5 6)) -1)
-      "interval-upper-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
+      "interval-upper-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
 
 (test (interval-upper-bound (make-interval '#(1 2 3) '#(4 5 6)) 3)
-      "interval-upper-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
+      "interval-upper-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
 
 (test (interval-upper-bound (make-interval '#(1 2 3) '#(4 5 6)) 4)
-      "interval-upper-bound: index is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
+      "interval-upper-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): ")
 
 (pp "interval-lower-bounds->list error tests")
 
 (test (interval-lower-bounds->list 1)
-      "interval-lower-bounds->list: argument is not an interval: ")
+      "interval-lower-bounds->list: The argument is not an interval: ")
 
 (pp "interval-upper-bounds->list error tests")
 
 (test (interval-upper-bounds->list #f)
-      "interval-upper-bounds->list: argument is not an interval: ")
+      "interval-upper-bounds->list: The argument is not an interval: ")
 
 (pp "interval-lower-bound, interval-upper-bound, interval-lower-bounds->list, and interval-upper-bounds->list result tests")
 
@@ -177,12 +177,12 @@
 (pp "interval-lower-bounds->vector error tests")
 
 (test (interval-lower-bounds->vector 1)
-      "interval-lower-bounds->vector: argument is not an interval: ")
+      "interval-lower-bounds->vector: The argument is not an interval: ")
 
 (pp "interval-upper-bounds-> error tests")
 
 (test (interval-upper-bounds->vector #f)
-      "interval-upper-bounds->vector: argument is not an interval: ")
+      "interval-upper-bounds->vector: The argument is not an interval: ")
 
 (pp "interval-lower-bound, interval-upper-bound, interval-lower-bounds->vector, and interval-upper-bounds->vector result tests")
 
@@ -248,7 +248,7 @@
 (pp "interval-volume error tests")
 
 (test (interval-volume #f)
-      "interval-volume: argument is not an interval: ")
+      "interval-volume: The argument is not an interval: ")
 
 (pp "interval-volume result tests")
 
@@ -313,13 +313,13 @@
 (pp "interval-contains-multi-index?  error tests")
 
 (test (interval-contains-multi-index? 1 1)
-      "interval-contains-multi-index?: argument is not an interval: ")
+      "interval-contains-multi-index?: The first argument is not an interval: ")
 
 (test (interval-contains-multi-index? (make-interval '#(1 2 3) '#(4 5 6)) 1)
-      "interval-contains-multi-index?: dimension of interval does not match number of arguments: ")
+      "interval-contains-multi-index?: The dimension of the first argument (an interval) does not match number of indices: ")
 
 (test (interval-contains-multi-index? (make-interval '#(1 2 3) '#(4 5 6)) 1 1/2 0.1)
-      "interval-contains-multi-index?: at least one multi-index component is not an exact integer: ")
+      "interval-contains-multi-index?: At least one multi-index component is not an exact integer: ")
 
 (pp "interval-contains-multi-index?  result tests")
 
@@ -339,10 +339,10 @@
 (pp "interval-for-each error tests")
 
 (test (interval-for-each (lambda (x) x) 1)
-      "interval-for-each: Argument is not a interval: ")
+      "interval-for-each: The second argument is not a interval: ")
 
 (test (interval-for-each 1 (make-interval '#(3) '#(4)))
-      "interval-for-each: Argument is not a procedure: ")
+      "interval-for-each: The first argument is not a procedure: ")
 
 (define (local-iota a b)
   (if (= a b)
@@ -478,10 +478,10 @@
 (pp "array-domain and array-getter error tests")
 
 (test (array-domain #f)
-      "array-domain: object is not an array: ")
+      "array-domain: The argument is not an array: ")
 
 (test (array-getter #f)
-      "array-getter: object is not an array: ")
+      "array-getter: The argument is not an array: ")
 
 (pp "array?, array-domain, and array-getter result tests")
 
@@ -517,7 +517,7 @@
 (pp "array-setter error tests")
 
 (test (array-setter #f)
-      "array-setter: object is not an mutable array: ")
+      "array-setter: The argument is not an mutable array: ")
 
 (pp "mutable-array? and array-setter result tests")
 
@@ -623,13 +623,13 @@
 		     values
 		     values)))
   (test (array-body a)
-	"array-body: argument is not a specialized array: ")
+	"array-body: The argument is not a specialized array: ")
   (test (array-indexer a)
-	"array-indexer: argument is not a specialized array: ")
+	"array-indexer: The argument is not a specialized array: ")
   (test (array-storage-class a)
-	"array-storage-class: argument is not a specialized array: ")
+	"array-storage-class: The argument is not a specialized array: ")
   (test (array-safe? a)
-	"array-safe?: argument is not a specialized array: "))
+	"array-safe?: The argument is not a specialized array: "))
 
 (pp "specialized-array error tests")
 
@@ -650,18 +650,18 @@
 (pp "array->specialized-array error tests")
 
 (test (array->specialized-array #f generic-storage-class)
-      "array->specialized-array: Argument is not an array: ")
+      "array->specialized-array: The first argument is not an array: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1) '#(2))
 					    list)
 				#f)
-      "array->specialized-array: result-storage-class is not a storage-class: ")
+      "array->specialized-array: The second argument is not a storage-class: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1) '#(2))
 					    list)
 				generic-storage-class
 				'a)
-      "array->specialized-array: safe? is not a boolean: ")
+      "array->specialized-array: The third argument is not a boolean: ")
 
 ;; We gotta make sure than the error checks work in all dimensions ...
 
@@ -1104,6 +1104,128 @@
 						       result-array-2)
 				       result)))))
 	  (pp "Arghh")))))
+
+(pp "array-reduce tests")
+
+(test (array-reduce 'a 'a)
+      "array-reduce: The second argument is not an array: ")
+
+(test (array-reduce 'a (make-array (make-interval '#(1) '#(3)) list))
+      "array-reduce: The first argument is not a procedure: ")
+
+;;; OK, how to test array-reduce?
+
+;;; Well, we take an associative, non-commutative operation,
+;;; multiplying 2x2 matrices, with data such that doing operations
+;;; in the opposite order gives the wrong answer, doing it for the
+;;; wrong interval (e.g., swapping axes) gives the wrong answer.
+
+;;; This is not in the same style as the other tests, which use random
+;;; data to a great extent, but I couldn't see how to choose random
+;;; data that would satisfy the constraints.
+
+
+(define matrix vector)
+
+(define (2x2-multiply A B)
+  (let ((a_11 (vector-ref A 0)) (a_12 (vector-ref A 1))
+        (a_21 (vector-ref A 2)) (a_22 (vector-ref A 3))
+        (b_11 (vector-ref B 0)) (b_12 (vector-ref B 1))
+        (b_21 (vector-ref B 2)) (b_22 (vector-ref B 3)))
+    (vector (+ (* a_11 b_11) (* a_12 b_21)) (+ (* a_11 b_12) (* a_12 b_22))
+            (+ (* a_21 b_11) (* a_22 b_21)) (+ (* a_21 b_12) (* a_22 b_22)))))
+
+(define A (make-array (make-interval '#(1) '#(11))
+                      (lambda (i)
+                        (if (even? i)
+                            (matrix 1 i
+                                    0 1)
+                            (matrix 1 0
+                                    i 1)))))
+
+(test (array-reduce 2x2-multiply A)
+      (array-fold-right 2x2-multiply (matrix 1 0 0 1) A))
+
+(test (not (equal? (array-reduce 2x2-multiply A)
+                   (array-fold 2x2-multiply (matrix 1 0 0 1) A)))
+      #t)
+
+
+(define A_2 (make-array (make-interval '#(1 1) '#(3 7))
+                        (lambda (i j)
+                          (if (and (even? i) (even? j))
+                              (matrix 1 i
+                                      j 1)
+                              (matrix 1 j
+                                      i -1)))))
+
+(test (array-reduce 2x2-multiply A_2)
+      (array-fold-right 2x2-multiply (matrix 1 0 0 1) A_2))
+
+(test (equal? (array-reduce 2x2-multiply A_2)
+              (array-fold 2x2-multiply (matrix 1 0 0 1) A_2))
+      #f)
+
+(test (equal? (array-reduce 2x2-multiply A_2)
+              (array-reduce 2x2-multiply (array-rotate A_2 1)))
+      #f)
+
+(define A_3 (make-array (make-interval '#(1 1 1) '#(3 5 4))
+                        (lambda (i j k)
+                          (if (and (even? i) (even? j))
+                              (matrix 1 i
+                                      j k)
+                              (matrix k j
+                                      i -1)))))
+
+(test (array-reduce 2x2-multiply A_3)
+      (array-fold-right 2x2-multiply (matrix 1 0 0 1) A_3))
+
+(test (equal? (array-reduce 2x2-multiply A_3)
+              (array-fold 2x2-multiply (matrix 1 0 0 1) A_3))
+      #f)
+
+(test (equal? (array-reduce 2x2-multiply A_3)
+              (array-reduce 2x2-multiply (array-rotate A_3 1)))
+      #f)
+
+(define A_4 (make-array (make-interval '#(1 1 1 1) '#(3 2 4 3))
+                        (lambda (i j k l)
+                          (if (and (even? i) (even? j))
+                              (matrix l i
+                                      j k)
+                              (matrix l k
+                                      i j)))))
+
+(test (array-reduce 2x2-multiply A_4)
+      (array-fold-right 2x2-multiply (matrix 1 0 0 1) A_4))
+
+(test (equal? (array-reduce 2x2-multiply A_4)
+              (array-fold 2x2-multiply (matrix 1 0 0 1) A_4))
+      #f)
+
+(test (equal? (array-reduce 2x2-multiply A_4)
+              (array-reduce 2x2-multiply (array-rotate A_4 1)))
+      #f)
+
+(define A_5 (make-array (make-interval '#(1 1 1 1 1) '#(3 2 4 3 3))
+                        (lambda (i j k l m)
+                          (if (even? m)
+                              (matrix (+ m l) i
+                                      j k)
+                              (matrix (- l m) k
+                                      i j)))))
+
+(test (array-reduce 2x2-multiply A_5)
+      (array-fold-right 2x2-multiply (matrix 1 0 0 1) A_5))
+
+(test (equal? (array-reduce 2x2-multiply A_5)
+              (array-fold 2x2-multiply (matrix 1 0 0 1) A_5))
+      #f)
+
+(test (equal? (array-reduce 2x2-multiply A_5)
+              (array-reduce 2x2-multiply (array-rotate A_5 1)))
+      #f)
 
 (pp "Some array-curry tests.")
 
@@ -1710,6 +1832,82 @@
 	      #t))))
   )
 
+(pp "array-rotate tests")
+
+;;; because array-rotate is built using the array-permute infrastructure, we
+;;; won't test as much
+
+(test (array-rotate 1 1)
+      "array-rotate: The first argument is not an array: ")
+
+(test (array-rotate (make-array (make-interval '#(0 0) '#(2 3)) list) 'a)
+      "array-rotate: The second argument is not an exact integer betweeen 0 (inclusive) and the array-dimension of the first argument (exclusive): ")
+
+(test (array-rotate (make-array (make-interval '#(0 0) '#(2 3)) list) 1.)
+      "array-rotate: The second argument is not an exact integer betweeen 0 (inclusive) and the array-dimension of the first argument (exclusive): ")
+
+(test (array-rotate (make-array (make-interval '#(0 0) '#(2 3)) list) 1/2)
+      "array-rotate: The second argument is not an exact integer betweeen 0 (inclusive) and the array-dimension of the first argument (exclusive): ")
+
+(test (array-rotate (make-array (make-interval '#(0 0) '#(2 3)) list) -1)
+      "array-rotate: The second argument is not an exact integer betweeen 0 (inclusive) and the array-dimension of the first argument (exclusive): ")
+
+(test (array-rotate (make-array (make-interval '#(0 0) '#(2 3)) list) 4)
+      "array-rotate: The second argument is not an exact integer betweeen 0 (inclusive) and the array-dimension of the first argument (exclusive): ")
+
+(for-each (lambda (n)
+            (let* ((upper-bounds (make-vector n 2))
+                   (lower-bounds (make-vector n 0))
+                   (domain (make-interval lower-bounds upper-bounds))
+                   (A (array->specialized-array (make-array domain list)))
+                   (immutable-A
+                    (let ((A (array->specialized-array A))) ;; copy A
+                      (make-array domain
+                                  (array-getter A))))
+                   (mutable-A
+                    (let ((A (array->specialized-array A))) ;; copy A
+                      (make-array domain
+                                  (array-getter A)
+                                  (array-setter A)))))
+              (for-each (lambda (dim)
+                          (let ((permutation
+                                 (list->vector
+                                  (append
+                                   (local-iota dim n)
+                                   (local-iota 0 dim)))))
+                          (let ((rA
+                                 (array-rotate A dim))
+                                (pA
+                                 (array-permute A permutation)))
+                            (if (not (and (specialized-array? rA)
+                                          (specialized-array? pA)
+                                          (myarray= rA pA)))
+                                (begin
+                                  (error "blah rotate specialized")
+                                  (pp 'crap))))
+                          (let ((rA
+                                 (array-rotate immutable-A dim))
+                                (pA
+                                 (array-permute immutable-A permutation)))
+                            (if (not (and (array? rA)
+                                          (array? pA)
+                                          (myarray= rA pA)))
+                                (begin
+                                  (error "blah rotate immutable")
+                                  (pp 'crap))))
+                          (let ((rA
+                                 (array-rotate mutable-A dim))
+                                (pA
+                                 (array-permute mutable-A permutation)))
+                            (if (not (and (mutable-array? rA)
+                                          (mutable-array? pA)
+                                          (myarray= rA pA)))
+                                (begin
+                                  (error "blah rotate mutable")
+                                  (pp 'crap))))))
+                        (iota n))))
+          (iota 5 1))
+
 (pp "interval-intersect tests")
 
 (let ((a (make-interval '#(0 0) '#(10 10)))
@@ -2127,6 +2325,49 @@
                     my-reversed-array)
           #t)))
 
+;; next test that the optional flip? argument is computed correctly.
+
+(for-each (lambda (n)
+            (let* ((upper-bounds (make-vector n 2))
+                   (lower-bounds (make-vector n 0))
+                   (domain (make-interval lower-bounds upper-bounds))
+                   (A (array->specialized-array (make-array domain list)))
+                   (immutable-A
+                    (let ((A (array->specialized-array A))) ;; copy A
+                      (make-array domain
+                                  (array-getter A))))
+                   (mutable-A
+                    (let ((A (array->specialized-array A))) ;; copy A
+                      (make-array domain
+                                  (array-getter A)
+                                  (array-setter A))))
+                   (flip? (make-vector n #t)))
+              (let ((r1 (array-reverse A))
+                    (r2 (array-reverse A flip?)))
+                (if (not (and (specialized-array? r1)
+                              (specialized-array? r2)
+                              (myarray= r1 r2)))
+                    (begin
+                      (error "blah reverse specialized")
+                      (pp 'crap))))
+              (let ((r1 (array-reverse mutable-A))
+                    (r2 (array-reverse mutable-A flip?)))
+                (if (not (and (mutable-array? r1)
+                              (mutable-array? r2)
+                              (myarray= r1 r2)))
+                    (begin
+                      (error "blah reverse mutable")
+                      (pp 'crap))))
+              (let ((r1 (array-reverse immutable-A))
+                    (r2 (array-reverse immutable-A flip?)))
+                (if (not (and (array? r1)
+                              (array? r2)
+                              (myarray= r1 r2)))
+                    (begin
+                      (error "blah reverse immutable")
+                      (pp 'crap))))))
+          (iota 5 1))
+
 (pp "array-assign! tests")
 
 (test (array-assign! 'a 'a)
@@ -2246,7 +2487,7 @@
       "make-array: The third argument is not a procedure: ")
 
 (test (array-dimension 'a)
-      "array-dimension: argument is not an array: ")
+      "array-dimension: The argument is not an array: ")
 
 (test (array-safe? (array->specialized-array (make-array (make-interval '#(0 0) '#(10 10)) list) generic-storage-class #t))
       #t)
@@ -2309,7 +2550,7 @@
 (pp "array->list and list->specialized-array")
 
 (test (array->list 'a)
-      "array->list: object is not an array: ")
+      "array->list: The argument is not an array: ")
 
 (test (list->specialized-array 'a 'b)
       "list->specialized-array: First argument is not a list: ")
@@ -2474,6 +2715,38 @@
 
 (test ((array-getter sparse-array) 0 0)
       1.)
+
+(define (palindrome? s)
+  (let ((n (string-length s)))
+    (or (< n 2)
+        (let* ((a
+                ;; an array accessing the characters of s
+                (make-array (make-interval '#(0)
+                                           (vector n))
+                            (lambda (i)
+                              (string-ref s i))))
+               (ra
+                ;; the array in reverse order
+                (array-reverse a))
+               (half-domain
+                (make-interval '#(0)
+                               (vector (quotient n 2)))))
+          (array-every
+           char=?
+           ;; the first half of s
+           (array-extract a half-domain)
+           ;; the second half of s
+           (array-extract ra half-domain))))))
+
+(for-each (lambda (s)
+            (for-each display
+                      (list "(palindrome? \""
+                            s
+                            "\") => "
+                            (palindrome? s)
+                            #\newline)))
+          '("" "a" "aa" "ab" "aba" "abc" "abba" "abca" "abbc"))
+
 
 (define make-pgm   cons)
 (define pgm-greys  car)


### PR DESCRIPTION
This commit has the following changes:

generic-arrays:

1.  Remove ##immutable-array-permute, ##mutable-array-permute, ##specialized-array-permute, which are no longer used.

2.  interval-rotate (new).

2.  Add ##rotation->permutation, use it in interval-rotate and in array-rotate.

test-arrays.scm:

1.  Add interval-rotate error and (minimal) result tests.

2.  Replace array-permute with much simpler array-rotate in separable transform and matrix multiply code.

srfi-179.scm:

1.  Document interval-rotate, and Add it to the list of routines added since SRFI 122.

2.  Use array-rotate instead of array-permute in separable transform and matrix multiplication examples.

3.  Note the sample matrix is a Hilbert matrix.

4.  Add 2020 as a copyright date.

5.  Add Draft #3 notice.

6.  Give the three rotations of a three-dimensional array as an example.

srfi-129.html:

1.  Regenerate from srfi-179.scm.

