### PR TITLE
Draft #3

### DIFF
--- a/srfi-179.html
+++ b/srfi-179.html
@@ -17,12 +17,13 @@
     <h2>Author</h2>
     <p>Bradley J. Lucier</p>
     <h2>Status</h2>
-    <p>This SRFI is currently in <em>draft</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+179+at+srfi+dotschemers+dot+org">srfi-179@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-179">archive</a>.</p>
+    <p>This SRFI is currently in <em>draft</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+179+at+srfi+dotschemers+dot+org">srfi-179@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-179">archive</a>.  There is a <a href="https://github.com/scheme-requests-for-implementation/srfi-179">git repository</a> of this document, a reference implementation, a test file, and other materials.</p>
     <ul>
       <li>Received: 2020/1/11</li>
       <li>60-day deadline: 2020/3/13</li>
-      <li>Draft #1 published: 2020/1/11</li>
-      <li>Draft #2 published: 2020/1/25</li></ul>
+      <li>Draft #1 published: 2020/01/11</li>
+      <li>Draft #2 published: 2020/01/27</li>
+      <li>Draft #3 published: 2020/02/04</li></ul>
     <h2>Abstract</h2>
     <p>This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a mapping, or function, from multi-indices of exact integers $i_0,\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices $i_0,\ldots,i_{d-1}$ that are valid for a given array form the <i>domain</i> of the array.  In this SRFI, each array's domain consists  of the cross product of nonempty intervals of exact integers $[l_0,u_0)\times[l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$ of $\mathbb Z^d$, $d$-tuples of integers.  Thus, we introduce a data type called $d$-<i>intervals</i>, or more briefly <i>intervals</i>, that encapsulates this notion. (We borrow this terminology from, e.g.,  Elias Zakon's <a href="http://www.trillia.com/zakon1.html">Basic Concepts of Mathematics</a>.) Specialized variants of arrays are specified to provide portable programs with efficient representations for common use cases.</p>
     <h2>Rationale</h2>
@@ -35,7 +36,7 @@
       <li>Encourage <b>bulk processing of arrays</b> rather than word-by-word operations.</li></ul>
     <p>This SRFI differs from the finalized <a href="https://srfi.schemers.org/srfi-122/">SRFI-122</a> in the following ways:</p>
     <ul>
-      <li>The procedures <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-rotate</code>, <code>array-reduce</code>, <code>array-assign!</code>, and <code>array-swap!</code> have been added together with some examples.</li>
+      <li>The procedures <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>interval-rotate</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-rotate</code>, <code>array-reduce</code>, <code>array-assign!</code>, and <code>array-swap!</code> have been added together with some examples.</li>
       <li>The discussion of Haar transforms as examples of separable transforms has been corrected.</li>
       <li>The documentation has a few more examples of image processing algorithms.</li>
       <li>Some matrix examples have been added to this document.</li></ul>
@@ -56,7 +57,7 @@
       <li><b>Restricting the domain of an array: </b>  If the domain of $B$, $D_B$, is a subset of the domain of $A$, then $T_{BA}(\vec i)=\vec i$ is a one-to-one affine mapping.  We define <code>array-extract</code> to define this common operation; it's like looking at a rectangular sub-part of a spreadsheet. We use it to extract the common part of overlapping domains of three arrays in an image processing example below. </li>
       <li><b>Tiling an array: </b>For various reasons (parallel processing, optimizing cache localization, GPU programming, etc.) one may wish to process a large array as a number of subarrays of the same dimensions, which we call <i>tiling</i> the array.  The routine <code>array-tile</code> returns a new array, each entry of which is a subarray extracted (in the sense of <code>array-extract</code>) from the input array.</li>
       <li><b>Translating the domain of an array: </b>If $\vec d$ is a vector of integers, then $T_{BA}(\vec i)=\vec i-\vec d$ is a one-to-one affine map of $D_B=\{\vec i+\vec d\mid \vec i\in D_A\}$ onto $D_A$. We call $D_B$ the <i>translate</i> of $D_A$, and we define <code>array-translate</code> to provide this operation.</li>
-      <li><b>Permuting the coordinates of an array: </b>If $\pi$ <a href="https://en.wikipedia.org/wiki/Permutation">permutes</a> the coordinates of a multi-index $\vec i$, and $\pi^{-1}$ is the inverse of $\pi$, then $T_{BA}(\vec i)=\pi (\vec i)$ is a one-to-one affine map from $D_B=\{\pi^{-1}(\vec i)\mid \vec i\in D_A\}$ onto $D_A$.  We provide <code>array-permute</code> for this operation. (The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) We also provide <code>array-rotate</code> for the special permutations that just rotate the axes.</li>
+      <li><b>Permuting the coordinates of an array: </b>If $\pi$ <a href="https://en.wikipedia.org/wiki/Permutation">permutes</a> the coordinates of a multi-index $\vec i$, and $\pi^{-1}$ is the inverse of $\pi$, then $T_{BA}(\vec i)=\pi (\vec i)$ is a one-to-one affine map from $D_B=\{\pi^{-1}(\vec i)\mid \vec i\in D_A\}$ onto $D_A$.  We provide <code>array-permute</code> for this operation. (The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) We also provide <code>array-rotate</code> for the special permutations that rotate the axes. For example, in three dimensions we have the following three rotations: $i\ j\ k\to j\ k\ i$; $i\ j\ k\to k\ i\ j$; and the trivial (identity) rotation $i\ j\ k\to i\ j\ k$.</li>
       <li><b>Currying an array: </b>Let's denote the cross product of two intervals $\text{Int}_1$ and $\text{Int}_2$ by $\text{Int}_1\times\text{Int}_2$; if $\vec j=(j_0,\ldots,j_{r-1})\in \text{Int}_1$ and $\vec i=(i_0,\ldots,i_{s-1})\in \text{Int}_2$, then $\vec j\times\vec i$, which we define to be $(j_0,\ldots,j_{r-1},i_0,\ldots,i_{s-1})$, is in $\text{Int}_1\times\text{Int}_2$. If $D_A=\text{Int}_1\times\text{Int}_2$ and $\vec j\in\text{Int}_1$, then $T_{BA}(\vec i)=\vec j\times\vec i$ is a one-to-one affine mapping from $D_B=\text{Int}_2$ into $D_A$.  For each vector $\vec j$ we can compute a new array in this way; we provide <code>array-curry</code> for this operation, which returns an array whose domain is $\text{Int}_1$ and whose elements are themselves arrays, each of which is defined on $\text{Int}_2$. Currying a two-dimensional array would be like organizing a spreadsheet into a one-dimensional array of rows of the spreadsheet.</li>
       <li><b>Traversing some indices in a multi-index in reverse order: </b>Consider an array $A$ with domain $D_A=[l_0,u_0)\times\cdots\times[l_{d-1},u_{d-1})$. Fix $D_B=D_A$ and assume we're given a vector of booleans $F$ ($F$ for &quot;flip?&quot;). Then define $T_{BA}:D_B\to D_A$ by $i_j\to i_j$ if $F_j$ is <code>#f</code> and $i_j\to u_j+l_j-1-i_j$ if  $F_j$ is <code>#t</code>. In other words,  we reverse the ordering of the $j$th coordinate of $\vec i$ if and only if $F_j$ is true. $T_{BA}$ is an affine mapping from $D_B\to D_A$, which defines a new array $B$, and we can provide <code>array-reverse</code> for this operation. Applying <code>array-reverse</code> to a two-dimensional spreadsheet might reverse the order of the rows or columns (or both).</li>
       <li><b>Uniformly sampling an array: </b>Assume that $A$ is an array with domain $[0,u_1)\times\cdots\times[0,u_{d-1})$ (i.e., an interval all of whose lower bounds are zero). We'll also assume the existence of vector $S$ of scale factors, which are positive exact integers. Let $D_B$ be a new interval with $j$th lower bound equal to zero and $j$th upper bound equal to $\operatorname{ceiling}(u_j/S_j)$ and let $T_{BA}(\vec i)_j=i_j\times S_j$, i.e., the $j$th coordinate is scaled by $S_j$.  ($D_B$ contains precisely those multi-indices that $T_{BA}$ maps into $D_A$.) Then $T_{BA}$ is an affine one-to-one mapping, and we provide <code>interval-scale</code> and <code>array-sample</code> for these operations.</li></ul>
@@ -120,6 +121,7 @@
         <a href="#interval-intersect">interval-intersect</a>,
         <a href="#interval-translate">interval-translate</a>,
         <a href="#interval-permute">interval-permute</a>,
+        <a href="#interval-rotate">interval-rotate</a>,
         <a href="#interval-scale">interval-scale</a>,
         <a href="#interval-cartesian-product">interval-cartesian-product</a>.</dd>
       <dt>Storage Classes</dt>
@@ -357,6 +359,9 @@
     <p>For example, if the argument interval represents $[0,4)\times[0,8)\times[0,21)\times [0,16)$ and the
       permutation is <code>#(3 0 1 2)</code>, then the result of <code>(interval-permute <var>interval</var> <var>permutation</var>)</code> will be
       the representation of $[0,16)\times [0,4)\times[0,8)\times[0,21)$.</p>
+    <p><b>Procedure: </b><code><a name="interval-rotate">interval-rotate</a> <var>interval</var> <var>dim</var></code></p>
+    <p>Informally, <code>(interval-rotate <var>interval</var> <var>dim</var>)</code> rotates the axes of <code><var>interval</var></code> <code><var>dim</var></code> places to the left.</p>
+    <p>More precisely, <code>(interval-rotate <var>interval</var> <var>dim</var>)</code> assumes that <code><var>interval</var></code> is an interval and <code><var>dim</var></code> is an exact integer between 0 (inclusive) and <code>(interval-dimension <var>interval</var>)</code> (exclusive).  It computes the permutation <code>(vector <var>dim</var> ... (- (interval-dimension <var>interval</var>) 1) 0 ... (- <var>dim</var> 1))</code> (unless <code><var>dim</var></code> is zero, in which case it constructs the identity permutation) and returns <code>(interval-permute <var>interval</var> <var>permutation</var>)</code>. It is an error if the arguments do not satisfy these conditions.</p>
     <p><b>Procedure: </b><code><a name="interval-scale">interval-scale</a> <var>interval</var> <var>scales</var></code></p>
     <p>If <code><var>interval</var></code> is a $d$-dimensional interval $[0,u_1)\times\cdots\times[0,u_{d-1})$ with all lower bounds zero, and <code><var>scales</var></code> is a length-$d$ vector of positive exact integers, which we'll denote by $\vec s$, then <code>interval-scale</code> returns the interval $[0,\operatorname{ceiling}(u_1/s_1))\times\cdots\times[0,\operatorname{ceiling}(u_{d-1}/s_{d-1})$.</p>
     <p>It is an error if  <code><var>interval</var></code> and <code><var>scales</var></code> do not satisfy this condition.</p>
@@ -1121,7 +1126,6 @@ indexer:       (lambda multi-index
       in the implementation are: DSSSL-style optional and keyword arguments; a
       unique object to indicate absent arguments; <code>define-structure</code>;
       and <code>define-macro</code>.</p>
-    <p>There is a <a href="https://github.com/scheme-requests-for-implementation/srfi-179">Git repository</a> of this document, a reference implementation, a test file, and other materials.</p>
     <h2>Relationship to other SRFIs</h2>
     <p>Final SRFIs <a href="#SRFI-25">25</a>, <a href="#SRFI-47">47</a>, <a href="#SRFI-58">58</a>, and <a href="#SRFI-63">63</a> deal with &quot;Multi-dimensional Array Primitives&quot;, &quot;Array&quot;, &quot;Array Notation&quot;,
       and &quot;Homogeneous and Heterogeneous Arrays&quot;, respectively.  Each of these previous SRFIs deal with what we call in this SRFI
@@ -1513,36 +1517,18 @@ Second-differences in the direction $k\times (1,-1)$:
 
 </pre>
     <p>You can see that with differences in the direction of only the first coordinate, the domains of the difference arrays get smaller in the first coordinate while staying the same in the second coordinate, and with differences in the diagonal directions, the domains of the difference arrays get smaller in both coordinates.</p>
-    <p><b>Separable operators. </b>Many multi-dimensional transforms in signal processing are <i>separable</i>, in that that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the <a href="https://arxiv.org/abs/1210.1944">Fast Hyperbolic Wavelet Transform</a>.  Each one-dimensional subdomain of the complete domain is called a <i>pencil</i>, and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can compute the multidimensional transform as follows:</p>
+    <p><b>Separable operators. </b>Many multi-dimensional transforms in signal processing are <i>separable</i>, in that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the <a href="https://arxiv.org/abs/1210.1944">Fast Hyperbolic Wavelet Transform</a>.  Each one-dimensional subdomain of the complete domain is called a <i>pencil</i>, and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can define the multidimensional transform as follows:</p>
     <pre><code>
 (define (make-separable-transform 1D-transform)
   (lambda (a)
-    (let* ((n
-	    (array-dimension a))
-	   (permutation
-	    ;; we start with the identity permutation
-	    (let ((result (make-vector n)))
-	      (do ((i 0 (fx+ i 1)))
-		  ((fx= i n) result)
-		(vector-set! result i i)))))
-      ;; We apply the one-dimensional transform to all pencils
-      ;; in each coordinate direction.
+    (let ((n (array-dimension a)))
       (do ((d 0 (fx+ d 1)))
-	  ((fx= d n))
-	;; Swap the d'th and n-1'st coordinates
-	(vector-set! permutation (fx- n 1) d)
-	(vector-set! permutation d (fx- n 1))
-	;; array-permute re-orders the coordinates to put the
-	;; d'th coordinate at the end, array-curry returns
-	;; an $n-1$-dimensional array of one-dimensional subarrays,
-	;; and 1D-transform is applied to each of those
-	;; one-dimensional sub-arrays.
-	(array-for-each 1D-transform
-			(array-curry (array-permute a permutation) 1))
-	;; return the permutation to the identity
-	(vector-set! permutation d d)
-	(vector-set! permutation (fx- n 1) (fx- n 1))))))
+          ((fx= d n))
+        (array-for-each
+         1D-transform
+         (array-curry (array-rotate a d) 1))))))
 </code></pre>
+    <p>Here we have cycled through all rotations, putting each axis in turn at the end, and then applied <code>1D-transform</code> to each of the pencils along that axis.</p>
     <p>Wavelet transforms in particular are calculated by recursively applying a transform to an array and then downsampling the array; the inverse transform recursively downsamples and then applies a transform.  So we define the following primitives: </p>
     <pre><code>
 (define (recursively-apply-transform-and-downsample transform)
@@ -1763,7 +1749,9 @@ Reconstructed image:
          (array-map -
                     subarray
                     (array-outer-product * column row)))))))
-
+</code></pre>
+    <p>We then define a $4\times 4$ <a href="https://en.wikipedia.org/wiki/Hilbert_matrix">Hilbert matrix</a>:</p>
+    <pre><code>
 (define A
   (array-&gt;specialized-array
    (make-array (make-interval '#(0 0)
@@ -1856,7 +1844,7 @@ Reconstructed image:
   (let ((a-rows
          (array-curry a 1))
         (b-columns
-         (array-curry (array-permute b '#(1 0)) 1)))
+         (array-curry (array-rotate b 1) 1)))
     (array-outer-product dot-product a-rows b-columns)))
 
 ;;; We'll check that the product of the result of LU
@@ -1886,7 +1874,7 @@ Reconstructed image:
       <li><a name="SRFI-63" href="https://srfi.schemers.org/srfi-63/">SRFI 63: Homogeneous and Heterogeneous Arrays</a>, by Aubrey Jaffer.</li>
       <li><a name="SRFI-164" href="https://srfi.schemers.org/srfi-164/">SRFI 164: Enhanced multi-dimensional Arrays</a>, by Per Bothner.</li></ol>
     <h2>Copyright</h2>
-    <p>&copy; 2016, 2018 Bradley J Lucier. All Rights Reserved.</p>
+    <p>&copy; 2016, 2018, 2020 Bradley J Lucier. All Rights Reserved.</p>
     <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: </p>
     <p>The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.</p>
     <p> THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/srfi-179.scm
+++ b/srfi-179.scm
@@ -61,8 +61,9 @@ MathJax.Hub.Config({
 	     (<a> href: "https://srfi-email.schemers.org/srfi-179" "archive")".  There is a "(<a> href: "https://github.com/scheme-requests-for-implementation/srfi-179"  "git repository")" of this document, a reference implementation, a test file, and other materials.")
 	(<ul> (<li> "Received: 2020/1/11")
               (<li> "60-day deadline: 2020/3/13")
-              (<li> "Draft #1 published: 2020/1/11")
-              (<li> "Draft #2 published: 2020/1/27"))
+              (<li> "Draft #1 published: 2020/01/11")
+              (<li> "Draft #2 published: 2020/01/27")
+              (<li> "Draft #3 published: 2020/02/04"))
 
 	(<h2> "Abstract")
 	(<p>
@@ -85,7 +86,7 @@ MathJax.Hub.Config({
          )
          (<p> "This SRFI differs from the finalized " (<a> href: "https://srfi.schemers.org/srfi-122/" "SRFI-122")" in the following ways:")
         (<ul>
-         (<li> "The procedures "(<code>'interval-for-each)", "(<code>'interval-cartesian-product)", "(<code>'array-outer-product)", "(<code>'array-tile)", "(<code>'array-rotate)", "(<code>'array-reduce)", "(<code>'array-assign!)", and "(<code>'array-swap!)" have been added together with some examples.")
+         (<li> "The procedures "(<code>'interval-for-each)", "(<code>'interval-cartesian-product)", "(<code>'interval-rotate)", "(<code>'array-outer-product)", "(<code>'array-tile)", "(<code>'array-rotate)", "(<code>'array-reduce)", "(<code>'array-assign!)", and "(<code>'array-swap!)" have been added together with some examples.")
          (<li> "The discussion of Haar transforms as examples of separable transforms has been corrected.")
          (<li> "The documentation has a few more examples of image processing algorithms.")
          (<li> "Some matrix examples have been added to this document."))
@@ -145,7 +146,7 @@ MathJax.Hub.Config({
 	       "If $\\pi$ "(<a> href: "https://en.wikipedia.org/wiki/Permutation" 'permutes)" the coordinates of a multi-index $\\vec i$, and $\\pi^{-1}$ is the inverse of $\\pi$, then "
 	       "$T_{BA}(\\vec i)=\\pi (\\vec i)$ is a one-to-one affine map from $D_B=\\{\\pi^{-1}(\\vec i)\\mid \\vec i\\in D_A\\}$ onto $D_A$.  We provide "(<code>'array-permute)" for this operation. "
 	       "(The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) "
-               "We also provide "(<code>'array-rotate)" for the special permutations that just rotate the axes.")
+               "We also provide "(<code>'array-rotate)" for the special permutations that rotate the axes. For example, in three dimensions we have the following three rotations: $i\\ j\\ k\\to j\\ k\\ i$; $i\\ j\\ k\\to k\\ i\\ j$; and the trivial (identity) rotation $i\\ j\\ k\\to i\\ j\\ k$.")
 	 (<li> (<b> "Currying an array: ")
 	       "Let's denote the cross product of two intervals $\\text{Int}_1$ and $\\text{Int}_2$ by $\\text{Int}_1\\times\\text{Int}_2$; "
 	       "if $\\vec j=(j_0,\\ldots,j_{r-1})\\in \\text{Int}_1$ and $\\vec i=(i_0,\\ldots,i_{s-1})\\in \\text{Int}_2$, then "
@@ -256,6 +257,7 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#interval-intersect" "interval-intersect")END
                  (<a> href: "#interval-translate" "interval-translate")END
                  (<a> href: "#interval-permute" "interval-permute") END
+                 (<a> href: "#interval-rotate" "interval-rotate") END
                  (<a> href: "#interval-scale" "interval-scale") END
                  (<a> href: "#interval-cartesian-product" "interval-cartesian-product")
                  ".")
@@ -540,6 +542,11 @@ $[l_{\\pi_0},u_{\\pi_0})\\times[l_{\\pi_1},u_{\\pi_1})\\times\\cdots\\times[l_{\
 (<p> "For example, if the argument interval represents $[0,4)\\times[0,8)\\times[0,21)\\times [0,16)$ and the
 permutation is "(<code>'#(3 0 1 2))", then the result of "(<code> "(interval-permute "(<var>'interval)" "(<var>' permutation)")")" will be
 the representation of $[0,16)\\times [0,4)\\times[0,8)\\times[0,21)$.")
+
+(format-lambda-list '(interval-rotate interval dim))
+(<p> "Informally, "(<code> "(interval-rotate "(<var>'interval)" "(<var>'dim)")")" rotates the axes of "(<code>(<var>'interval))" "(<code>(<var>'dim))" places to the left.")
+(<p> "More precisely, "(<code> "(interval-rotate "(<var>'interval)" "(<var> 'dim)")")" assumes that "(<code>(<var>'interval))" is an interval and "(<code>(<var>'dim))" is an exact integer between 0 (inclusive) and "(<code> "(interval-dimension "(<var>'interval)")")" (exclusive).  It computes the permutation "(<code>"(vector "(<var>'dim)" ... (- (interval-dimension "(<var>'interval)") 1) 0 ... (- "(<var>'dim)" 1))")" (unless "(<code>(<var>'dim))" is zero, in which case it constructs the identity permutation) and returns "(<code>"(interval-permute "(<var>'interval)" "(<var>'permutation)")")". It is an error if the arguments do not satisfy these conditions.")
+
 
 (format-lambda-list '(interval-scale interval scales))
 (<p> "If "(<code>(<var>'interval))" is a $d$-dimensional interval $[0,u_1)\\times\\cdots\\times[0,u_{d-1})$ with all lower bounds zero, "
@@ -1881,36 +1888,18 @@ Second-differences in the direction $k\\times (1,-1)$:
 
 
 
-(<p> (<b> "Separable operators. ")"Many multi-dimensional transforms in signal processing are "(<i> 'separable)", in that that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the "(<a> href: "https://arxiv.org/abs/1210.1944" "Fast Hyperbolic Wavelet Transform")".  Each one-dimensional subdomain of the complete domain is called a "(<i> 'pencil)", and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can compute the multidimensional transform as follows:")
+(<p> (<b> "Separable operators. ")"Many multi-dimensional transforms in signal processing are "(<i> 'separable)", in that the multi-dimensional transform can be computed by applying one-dimensional transforms in each of the coordinate directions.  Examples of such transforms include the Fast Fourier Transform and the "(<a> href: "https://arxiv.org/abs/1210.1944" "Fast Hyperbolic Wavelet Transform")".  Each one-dimensional subdomain of the complete domain is called a "(<i> 'pencil)", and the same one-dimensional transform is applied to all pencils in a given direction. Given the one-dimensional array transform, one can define the multidimensional transform as follows:")
 (<pre> (<code>"
 (define (make-separable-transform 1D-transform)
   (lambda (a)
-    (let* ((n
-	    (array-dimension a))
-	   (permutation
-	    ;; we start with the identity permutation
-	    (let ((result (make-vector n)))
-	      (do ((i 0 (fx+ i 1)))
-		  ((fx= i n) result)
-		(vector-set! result i i)))))
-      ;; We apply the one-dimensional transform to all pencils
-      ;; in each coordinate direction.
+    (let ((n (array-dimension a)))
       (do ((d 0 (fx+ d 1)))
-	  ((fx= d n))
-	;; Swap the d'th and n-1'st coordinates
-	(vector-set! permutation (fx- n 1) d)
-	(vector-set! permutation d (fx- n 1))
-	;; array-permute re-orders the coordinates to put the
-	;; d'th coordinate at the end, array-curry returns
-	;; an $n-1$-dimensional array of one-dimensional subarrays,
-	;; and 1D-transform is applied to each of those
-	;; one-dimensional sub-arrays.
-	(array-for-each 1D-transform
-			(array-curry (array-permute a permutation) 1))
-	;; return the permutation to the identity
-	(vector-set! permutation d d)
-	(vector-set! permutation (fx- n 1) (fx- n 1))))))
+          ((fx= d n))
+        (array-for-each
+         1D-transform
+         (array-curry (array-rotate a d) 1))))))
 "))
+(<p> "Here we have cycled through all rotations, putting each axis in turn at the end, and then applied "(<code>'1D-transform)" to each of the pencils along that axis.")
 (<p> "Wavelet transforms in particular are calculated by recursively applying a transform to an array and then downsampling the array; the inverse transform recursively downsamples and then applies a transform.  So we define the following primitives: ")
 (<pre>(<code>"
 (define (recursively-apply-transform-and-downsample transform)
@@ -2134,7 +2123,10 @@ The code uses "(<code>'array-assign!)", "(<code>'specialized-array-share)", "(<c
          (array-map -
                     subarray
                     (array-outer-product * column row)))))))
-
+"))
+(<p> "We then define a $4\\times 4$ "(<a> href: "https://en.wikipedia.org/wiki/Hilbert_matrix" "Hilbert matrix")":")
+(<pre>
+ (<code>"
 (define A
   (array->specialized-array
    (make-array (make-interval '#(0 0)
@@ -2228,7 +2220,7 @@ The code uses "(<code>'array-assign!)", "(<code>'specialized-array-share)", "(<c
   (let ((a-rows
          (array-curry a 1))
         (b-columns
-         (array-curry (array-permute b '#(1 0)) 1)))
+         (array-curry (array-rotate b 1) 1)))
     (array-outer-product dot-product a-rows b-columns)))
 
 ;;; We'll check that the product of the result of LU
@@ -2261,7 +2253,7 @@ The code uses "(<code>'array-assign!)", "(<code>'specialized-array-share)", "(<c
  (<li> (<a> name: 'SRFI-63 href: "https://srfi.schemers.org/srfi-63/" "SRFI 63: Homogeneous and Heterogeneous Arrays")", by Aubrey Jaffer.")
  (<li> (<a> name: 'SRFI-164 href: "https://srfi.schemers.org/srfi-164/" "SRFI 164: Enhanced multi-dimensional Arrays")", by Per Bothner."))
 (<h2> "Copyright")
-(<p> (<unprotected> "&copy;")" 2016, 2018 Bradley J Lucier. All Rights Reserved.")
+(<p> (<unprotected> "&copy;")" 2016, 2018, 2020 Bradley J Lucier. All Rights Reserved.")
 (<p> "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: ")
 (<p> "The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.")
 (<p> " THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
generic-arrays:

1.  Remove ##immutable-array-permute, ##mutable-array-permute, ##specialized-array-permute, which are no longer used.

2.  interval-rotate (new).

2.  Add ##rotation->permutation, use it in interval-rotate and in array-rotate.

test-arrays.scm:

1.  Add interval-rotate error and (minimal) result tests.

2.  Replace array-permute with much simpler array-rotate in separable transform and matrix multiply code.

srfi-179.scm:

1.  Document interval-rotate, and Add it to the list of routines added since SRFI 122.

2.  Use array-rotate instead of array-permute in separable transform and matrix multiplication examples.

3.  Note the sample matrix is a Hilbert matrix.

4.  Add 2020 as a copyright date.

5.  Add Draft #3 notice.

6.  Give the three rotations of a three-dimensional array as an example.

srfi-129.html:

1.  Regenerate from srfi-179.scm.