### PR TITLE
Draft #7

### DIFF
--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -3212,44 +3212,6 @@
                         multi-index))))
             domain)))))
 
-(define (array-swap! A B)
-  (cond ((not (mutable-array? A))
-         (error "array-swap!: The first argument is not a mutable array: " A B))
-        ((not (mutable-array? B))
-         (error "array-swap!: The second argument is not a mutable array: " A B))
-        ((not (interval= (%%array-domain A)
-                         (%%array-domain B)))
-         (error "array-swap!: The arguments do not have the same domain: " A B))
-        (else
-         (let ((A_ (%%array-getter A))
-               (A! (%%array-setter A))
-               (B_ (%%array-getter B))
-               (B! (%%array-setter B)))
-           (%%interval-for-each
-            (case (%%array-dimension A)
-              ((1) (lambda (i)
-                     (let ((temp (A_ i)))
-                       (A! (B_ i) i)
-                       (B! temp   i))))
-              ((2) (lambda (i j)
-                     (let ((temp (A_ i j)))
-                       (A! (B_ i j) i j)
-                       (B! temp     i j))))
-              ((3) (lambda (i j k)
-                     (let ((temp (A_ i j k)))
-                       (A! (B_ i j k) i j k)
-                       (B! temp       i j k))))
-              ((4) (lambda (i j k l)
-                     (let ((temp (A_ i j k l)))
-                       (A! (B_ i j k l) i j k l)
-                       (B! temp         i j k l))))
-              (else
-               (lambda multi-index
-                 (let ((temp (apply A_ multi-index)))
-                   (apply A! (apply B_ multi-index) multi-index)
-                   (apply B! temp                   multi-index)))))
-            (%%array-domain A))))))
-
 ;;; Because array-ref and array-set! have variable number of arguments, and
 ;;; they have to check on every call that the first argument is an array,
 ;;; compiled code using array-ref and array-set! can take up to three times

--- a/generic-arrays.scm
+++ b/generic-arrays.scm
@@ -18,58 +18,27 @@
         obj)))))
 
 (cond-expand
- (gambit
-  ;; define some R7RS small procedures for Gambit.
-  ;; sub@vector-move! uses memmove in C back end
-  (begin
-    (define (vector-copy! to at from start end)
-      (subvector-move! from start end to at))
-    (define (s8vector-copy! to at from start end)
-      (subs8vector-move! from start end to at))
-    (define (s16vector-copy! to at from start end)
-      (subs16vector-move! from start end to at))
-    (define (s32vector-copy! to at from start end)
-      (subs32vector-move! from start end to at))
-    (define (s64vector-copy! to at from start end)
-      (subs64vector-move! from start end to at))
-    (define (u8vector-copy! to at from start end)
-      (subu8vector-move! from start end to at))
-    (define (u16vector-copy! to at from start end)
-      (subu16vector-move! from start end to at))
-    (define (u32vector-copy! to at from start end)
-      (subu32vector-move! from start end to at))
-    (define (u64vector-copy! to at from start end)
-      (subu64vector-move! from start end to at))
-    (define (f32vector-copy! to at from start end)
-      (subf32vector-move! from start end to at))
-    (define (f64vector-copy! to at from start end)
-      (subf64vector-move! from start end to at))
-    ;; next two are not R7RS small
-    (define (c64vector-copy! to at from start end)
-      (subf32vector-move! from (* 2 start) (* 2 end) to (* 2 at)))
-    (define (c128vector-copy! to at from start end)
-      (subf64vector-move! from (* 2 start) (* 2 end) to (* 2 at)))))
- (r7rs
+ ((or gambit r7rs)
   ;; The other procedures are in R7RS small
   (begin
     (define (c64vector-copy! to at from start end)
       (f32vector-copy! to (* 2 at) from (* 2 start) (* 2 end)))
     (define (c128vector-copy! to at from start end)
       (f64vector-copy! to (* 2 at) from (* 2 start) (* 2 end)))))
-  (else
-   ;; Punt
-   (begin
-     (define vector-copy! #f)
-     (define s8vector-copy! #f)
-     (define s16vector-copy! #f)
-     (define s32vector-copy! #f)
-     (define s64vector-copy! #f)
-     (define u8vector-copy! #f)
-     (define u16vector-copy! #f)
-     (define u32vector-copy! #f)
-     (define u64vector-copy! #f)
-     (define c64vector-copy! #f)
-     (define c128vector-copy! #f))))
+ (else
+  ;; Punt
+  (begin
+    (define vector-copy! #f)
+    (define s8vector-copy! #f)
+    (define s16vector-copy! #f)
+    (define s32vector-copy! #f)
+    (define s64vector-copy! #f)
+    (define u8vector-copy! #f)
+    (define u16vector-copy! #f)
+    (define u32vector-copy! #f)
+    (define u64vector-copy! #f)
+    (define c64vector-copy! #f)
+    (define c128vector-copy! #f))))
 
 
 ;;; We need a multi-argument every, but not as fancy as in Olin Shiver's
@@ -78,13 +47,13 @@
 (define (%%every pred list . lists)
   (if (pair? lists)
       (let loop ((lists (cons list lists)))
-	(or (null? (car lists))
-	    (and (apply pred (map car lists))
-		 (loop (map cdr lists)))))
+        (or (null? (car lists))
+            (and (apply pred (map car lists))
+                 (loop (map cdr lists)))))
       (let loop ((list list))
-	(or (null? list)
-	    (and (pred (car list))
-		 (loop (cdr list)))))))
+        (or (null? list)
+            (and (pred (car list))
+                 (loop (cdr list)))))))
 
 ;;; the following is used in error checks.
 
@@ -92,25 +61,25 @@
 
   (define (every1 vec i)
     (or (< i 0)
-	(and (pred (vector-ref vec i))
-	     (every1 vec (- i 1)))))
+        (and (pred (vector-ref vec i))
+             (every1 vec (- i 1)))))
 
   (define (every2 vec1 vec2 i)
     (or (< i 0)
-	(and (pred (vector-ref vec1 i) (vector-ref vec2 i))
-	     (every2 vec1 vec2 (- i 1)))))
+        (and (pred (vector-ref vec1 i) (vector-ref vec2 i))
+             (every2 vec1 vec2 (- i 1)))))
 
   (define (every-general vecs i)
     (or (< i 0)
-	(and (apply pred (map (lambda (vec) (vector-ref vec i)) vecs))
-	     (every-general vecs (- i 1)))))
+        (and (apply pred (map (lambda (vec) (vector-ref vec i)) vecs))
+             (every-general vecs (- i 1)))))
 
   (cond ((eq? vec2 (macro-absent-obj))
-	 (every1 vec (- (vector-length vec) 1)))
-	((null? vecs)
-	 (every2 vec vec2 (- (vector-length vec) 1)))
-	(else
-	 (every-general (cons vec (cons vec2 vecs)) (- (vector-length vec) 1)))))
+         (every1 vec (- (vector-length vec) 1)))
+        ((null? vecs)
+         (every2 vec vec2 (- (vector-length vec) 1)))
+        (else
+         (every-general (cons vec (cons vec2 vecs)) (- (vector-length vec) 1)))))
 
 ;;; requires vector-map, vector-copy function
 
@@ -195,141 +164,141 @@
 
 (define (interval-dimension interval)
   (cond ((not (interval? interval))
-	 (error "interval-dimension: The argument is not an interval: " interval))
-	(else
-	 (%%interval-dimension interval))))
+         (error "interval-dimension: The argument is not an interval: " interval))
+        (else
+         (%%interval-dimension interval))))
 
 (define (interval-lower-bound interval i)
   (cond ((not (interval? interval))
-	 (error "interval-lower-bound: The first argument is not an interval: " interval i))
-	((not (exact-integer? i))
-	 (error "interval-lower-bound: The second argument is not an exact integer: " interval i))
-	((not (< -1 i (%%interval-dimension interval)))
-	 (error "interval-lower-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
-	(else
-	 (%%interval-lower-bound interval i))))
+         (error "interval-lower-bound: The first argument is not an interval: " interval i))
+        ((not (exact-integer? i))
+         (error "interval-lower-bound: The second argument is not an exact integer: " interval i))
+        ((not (< -1 i (%%interval-dimension interval)))
+         (error "interval-lower-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
+        (else
+         (%%interval-lower-bound interval i))))
 
 (define (interval-upper-bound interval i)
   (cond ((not (interval? interval))
-	 (error "interval-upper-bound: The first argument is not an interval: " interval i))
-	((not (exact-integer? i))
-	 (error "interval-upper-bound: The second argument is not an exact integer: " interval i))
-	((not (< -1 i (%%interval-dimension interval)))
-	 (error "interval-upper-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
-	(else
-	 (%%interval-upper-bound interval i))))
+         (error "interval-upper-bound: The first argument is not an interval: " interval i))
+        ((not (exact-integer? i))
+         (error "interval-upper-bound: The second argument is not an exact integer: " interval i))
+        ((not (< -1 i (%%interval-dimension interval)))
+         (error "interval-upper-bound: The second argument is not between 0 (inclusive) and (interval-dimension interval) (exclusive): " interval i))
+        (else
+         (%%interval-upper-bound interval i))))
 
 (define (interval-lower-bounds->vector interval)
   (cond ((not (interval? interval))
-	 (error "interval-lower-bounds->vector: The argument is not an interval: " interval))
-	(else
-	 (%%interval-lower-bounds->vector interval))))
+         (error "interval-lower-bounds->vector: The argument is not an interval: " interval))
+        (else
+         (%%interval-lower-bounds->vector interval))))
 
 (define (interval-upper-bounds->vector interval)
   (cond ((not (interval? interval))
-	 (error "interval-upper-bounds->vector: The argument is not an interval: " interval))
-	(else
-	 (%%interval-upper-bounds->vector interval))))
+         (error "interval-upper-bounds->vector: The argument is not an interval: " interval))
+        (else
+         (%%interval-upper-bounds->vector interval))))
 
 (define (interval-lower-bounds->list interval)
   (cond ((not (interval? interval))
-	 (error "interval-lower-bounds->list: The argument is not an interval: " interval))
-	(else
-	 (%%interval-lower-bounds->list interval))))
+         (error "interval-lower-bounds->list: The argument is not an interval: " interval))
+        (else
+         (%%interval-lower-bounds->list interval))))
 
 (define (interval-upper-bounds->list interval)
   (cond ((not (interval? interval))
-	 (error "interval-upper-bounds->list: The argument is not an interval: " interval))
-	(else
-	 (%%interval-upper-bounds->list interval))))
+         (error "interval-upper-bounds->list: The argument is not an interval: " interval))
+        (else
+         (%%interval-upper-bounds->list interval))))
 
 (define (interval-projections interval right-dimension)
   (cond ((not (interval? interval))
-	 (error "interval-projections: The first argument is not an interval: " interval right-dimension))
-	((not (< 1 (%%interval-dimension interval)))  ;; redundant check, but useful error message
-	 (error "interval-projections: The dimension of the first argument is not greater than 1: " interval right-dimension))
-	((not (exact-integer? right-dimension))
-	 (error "interval-projections: The second argument is not an exact integer: " interval right-dimension))
-	((not (< 0 right-dimension (%%interval-dimension interval)))
-	 (error "interval-projections: The second argument is not between 0 and the dimension of the first argument (exclusive): " interval right-dimension))
-	(else
-	 (%%interval-projections interval right-dimension))))
+         (error "interval-projections: The first argument is not an interval: " interval right-dimension))
+        ((not (< 1 (%%interval-dimension interval)))  ;; redundant check, but useful error message
+         (error "interval-projections: The dimension of the first argument is not greater than 1: " interval right-dimension))
+        ((not (exact-integer? right-dimension))
+         (error "interval-projections: The second argument is not an exact integer: " interval right-dimension))
+        ((not (< 0 right-dimension (%%interval-dimension interval)))
+         (error "interval-projections: The second argument is not between 0 and the dimension of the first argument (exclusive): " interval right-dimension))
+        (else
+         (%%interval-projections interval right-dimension))))
 
 (define (%%interval-projections interval right-dimension)
   (let* ((n (%%interval-dimension interval))
-	 (left-dimension (fx- n right-dimension))
-	 (lower-bounds (%%interval-lower-bounds interval))
-	 (upper-bounds (%%interval-upper-bounds interval))
-	 (left-lower-bounds (make-vector left-dimension))
-	 (left-upper-bounds (make-vector left-dimension))
-	 (right-lower-bounds (make-vector (- n left-dimension)))
-	 (right-upper-bounds (make-vector (- n left-dimension))))
+         (left-dimension (fx- n right-dimension))
+         (lower-bounds (%%interval-lower-bounds interval))
+         (upper-bounds (%%interval-upper-bounds interval))
+         (left-lower-bounds (make-vector left-dimension))
+         (left-upper-bounds (make-vector left-dimension))
+         (right-lower-bounds (make-vector (- n left-dimension)))
+         (right-upper-bounds (make-vector (- n left-dimension))))
     (do ((i 0 (+ i 1)))
-	((= i left-dimension)
-	 (do ((i i (+ i 1)))
-	     ((= i n)
-	      (values (make-%%interval left-lower-bounds
-				       left-upper-bounds)
-		      (make-%%interval right-lower-bounds
-				       right-upper-bounds)))
-	   (vector-set! right-lower-bounds (- i left-dimension) (vector-ref lower-bounds i))
-	   (vector-set! right-upper-bounds (- i left-dimension) (vector-ref upper-bounds i))))
+        ((= i left-dimension)
+         (do ((i i (+ i 1)))
+             ((= i n)
+              (values (make-%%interval left-lower-bounds
+                                       left-upper-bounds)
+                      (make-%%interval right-lower-bounds
+                                       right-upper-bounds)))
+           (vector-set! right-lower-bounds (- i left-dimension) (vector-ref lower-bounds i))
+           (vector-set! right-upper-bounds (- i left-dimension) (vector-ref upper-bounds i))))
       (vector-set! left-lower-bounds i (vector-ref lower-bounds i))
       (vector-set! left-upper-bounds i (vector-ref upper-bounds i)))))
 
 (define (permutation? permutation)
   (and (vector? permutation)
        (let* ((n (vector-length permutation))
-	      (permutation-range (make-vector n #f)))
-	 ;; we'll write things into permutation-range
-	 ;; each box should be written only once
-	 (let loop ((i 0))
-	   (or (= i n)
-	       (let ((p_i (vector-ref permutation i)))
-		 (and (fixnum? p_i) ;; a permutation index can't be a bignum
-		      (< -1 p_i n)
-		      (not (vector-ref permutation-range p_i))
-		      (let ()
-			(vector-set! permutation-range p_i #t)
-			(loop (+ i 1))))))))))
+              (permutation-range (make-vector n #f)))
+         ;; we'll write things into permutation-range
+         ;; each box should be written only once
+         (let loop ((i 0))
+           (or (= i n)
+               (let ((p_i (vector-ref permutation i)))
+                 (and (fixnum? p_i) ;; a permutation index can't be a bignum
+                      (< -1 p_i n)
+                      (not (vector-ref permutation-range p_i))
+                      (let ()
+                        (vector-set! permutation-range p_i #t)
+                        (loop (+ i 1))))))))))
 
 
 
 (define (%%vector-permute vector permutation)
   (let* ((n (vector-length vector))
-	 (result (make-vector n)))
+         (result (make-vector n)))
     (do ((i 0 (+ i 1)))
-	((= i n) result)
+        ((= i n) result)
       (vector-set! result i (vector-ref vector (vector-ref permutation i))))))
 
 (define (%%vector-permute->list vector permutation)
   (do ((i (- (vector-length vector) 1) (- i 1))
        (result '() (cons (vector-ref vector (vector-ref permutation i))
-			 result)))
+                         result)))
       ((< i 0) result)))
 
 (define (%%permutation-invert permutation)
   (let* ((n (vector-length permutation))
-	 (result (make-vector n)))
+         (result (make-vector n)))
     (do ((i 0 (+ i 1)))
-	((= i n) result)
+        ((= i n) result)
       (vector-set! result (vector-ref permutation i) i))))
 
 
 
 (define (%%interval-permute interval permutation)
   (make-%%interval (%%vector-permute (%%interval-lower-bounds interval) permutation)
-		   (%%vector-permute (%%interval-upper-bounds interval) permutation)))
+                   (%%vector-permute (%%interval-upper-bounds interval) permutation)))
 
 (define (interval-permute interval permutation)
   (cond ((not (interval? interval))
-	 (error "interval-permute: The first argument is not an interval: " interval permutation))
-	((not (permutation? permutation))
-	 (error "interval-permute: The second argument is not a permutation: " interval permutation))
-	((not (= (interval-dimension interval) (vector-length permutation)))
-	 (error "interval-permute: The dimension of the first argument (an interval) does not equal the length of the second (a permutation): " interval permutation))
-	(else
-	 (%%interval-permute interval permutation))))
+         (error "interval-permute: The first argument is not an interval: " interval permutation))
+        ((not (permutation? permutation))
+         (error "interval-permute: The second argument is not a permutation: " interval permutation))
+        ((not (= (interval-dimension interval) (vector-length permutation)))
+         (error "interval-permute: The dimension of the first argument (an interval) does not equal the length of the second (a permutation): " interval permutation))
+        (else
+         (%%interval-permute interval permutation))))
 
 (define (translation? translation)
   (and (vector? translation)
@@ -337,18 +306,18 @@
 
 (define (interval-translate interval translation)
   (cond ((not (interval? interval))
-	 (error "interval-translate: The first argument is not an interval: " interval translation))
-	((not (translation? translation))
-	 (error "interval-translate: The second argument is not a vector of exact integers: " interval translation))
-	((not (= (%%interval-dimension interval)
-		 (vector-length translation)))
-	 (error "interval-translate: The dimension of the first argument (an interval) does not equal the length of the second (a vector): " interval translation))
-	(else
-	 (%%interval-translate interval translation))))
+         (error "interval-translate: The first argument is not an interval: " interval translation))
+        ((not (translation? translation))
+         (error "interval-translate: The second argument is not a vector of exact integers: " interval translation))
+        ((not (= (%%interval-dimension interval)
+                 (vector-length translation)))
+         (error "interval-translate: The dimension of the first argument (an interval) does not equal the length of the second (a vector): " interval translation))
+        (else
+         (%%interval-translate interval translation))))
 
 (define (%%interval-translate Interval translation)
   (make-%%interval (vector-map + (interval-lower-bounds->vector Interval) translation)
-		   (vector-map + (interval-upper-bounds->vector Interval) translation)))
+                   (vector-map + (interval-upper-bounds->vector Interval) translation)))
 
 (define (%%interval-scale interval scales)
   (let* ((uppers (%%interval-upper-bounds->vector interval))
@@ -387,49 +356,49 @@
 
 (define (interval-dilate interval lower-diffs upper-diffs)
   (cond ((not (interval? interval))
-	 (error "interval-dilate: The first argument is not an interval: " interval lower-diffs upper-diffs))
-	((not (and (vector? lower-diffs)
+         (error "interval-dilate: The first argument is not an interval: " interval lower-diffs upper-diffs))
+        ((not (and (vector? lower-diffs)
                    (%%vector-every exact-integer? lower-diffs)))
-	 (error "interval-dilate: The second argument is not a vector of exact integers: " interval lower-diffs upper-diffs))
-	((not (and (vector? upper-diffs)
+         (error "interval-dilate: The second argument is not a vector of exact integers: " interval lower-diffs upper-diffs))
+        ((not (and (vector? upper-diffs)
                    (%%vector-every exact-integer? upper-diffs)))
-	 (error "interval-dilate: The third argument is not a vector of exact integers: " interval lower-diffs upper-diffs))
-	((not (= (vector-length lower-diffs)
-		 (vector-length upper-diffs)
-		 (%%interval-dimension interval)))
-	 (error "interval-dilate: The second and third arguments must have the same length as the dimension of the first argument: " interval lower-diffs upper-diffs))
-	(else
-	 (let ((new-lower-bounds (vector-map + (%%interval-lower-bounds interval) lower-diffs))
-	       (new-upper-bounds (vector-map + (%%interval-upper-bounds interval) upper-diffs)))
-	   (if (%%vector-every < new-lower-bounds new-upper-bounds)
-	       (make-%%interval new-lower-bounds new-upper-bounds)
-	       (error "interval-dilate: The resulting interval is empty: " interval lower-diffs upper-diffs))))))
+         (error "interval-dilate: The third argument is not a vector of exact integers: " interval lower-diffs upper-diffs))
+        ((not (= (vector-length lower-diffs)
+                 (vector-length upper-diffs)
+                 (%%interval-dimension interval)))
+         (error "interval-dilate: The second and third arguments must have the same length as the dimension of the first argument: " interval lower-diffs upper-diffs))
+        (else
+         (let ((new-lower-bounds (vector-map + (%%interval-lower-bounds interval) lower-diffs))
+               (new-upper-bounds (vector-map + (%%interval-upper-bounds interval) upper-diffs)))
+           (if (%%vector-every < new-lower-bounds new-upper-bounds)
+               (make-%%interval new-lower-bounds new-upper-bounds)
+               (error "interval-dilate: The resulting interval is empty: " interval lower-diffs upper-diffs))))))
 
 (define (%%interval-volume interval)
   (do ((i (- (%%interval-dimension interval) 1) (- i 1))
        (result 1 (let ()
-		   (* result (- (%%interval-upper-bound interval i)
-				(%%interval-lower-bound interval i))))))
+                   (* result (- (%%interval-upper-bound interval i)
+                                (%%interval-lower-bound interval i))))))
       ((< i 0) result)))
 
 (define (interval-volume interval)
   (cond ((not (interval? interval))
-	 (error "interval-volume: The argument is not an interval: " interval))
-	(else
-	 (%%interval-volume interval))))
+         (error "interval-volume: The argument is not an interval: " interval))
+        (else
+         (%%interval-volume interval))))
 
 (define (%%interval= interval1 interval2)
   (and (equal? (%%interval-upper-bounds interval1)
-	       (%%interval-upper-bounds interval2))
+               (%%interval-upper-bounds interval2))
        (equal? (%%interval-lower-bounds interval1)
-	       (%%interval-lower-bounds interval2))))
+               (%%interval-lower-bounds interval2))))
 
 (define (interval= interval1 interval2)
   (cond ((not (and (interval? interval1)
-		   (interval? interval2)))
-	 (error "interval=: Not all arguments are intervals: " interval1 interval2))
-	(else
-	 (%%interval= interval1 interval2))))
+                   (interval? interval2)))
+         (error "interval=: Not all arguments are intervals: " interval1 interval2))
+        (else
+         (%%interval= interval1 interval2))))
 
 (define (%%interval-subset? interval1 interval2)
   (and (= (%%interval-dimension interval1) (%%interval-dimension interval2))
@@ -438,34 +407,34 @@
 
 (define (interval-subset? interval1 interval2)
   (cond ((not (and (interval? interval1)
-		   (interval? interval2)))
-	 (error "interval-subset?: Not all arguments are intervals: " interval1 interval2))
+                   (interval? interval2)))
+         (error "interval-subset?: Not all arguments are intervals: " interval1 interval2))
         ((not (= (%%interval-dimension interval1)
                  (%%interval-dimension interval2)))
          (error "interval-subset?: The arguments do not have the same dimension: " interval1 interval2))
-	(else
-	 (%%interval-subset? interval1 interval2))))
+        (else
+         (%%interval-subset? interval1 interval2))))
 
 (define (%%interval-intersect intervals)
   (let ((lower-bounds (apply vector-map max (map %%interval-lower-bounds intervals)))
-	(upper-bounds (apply vector-map min (map %%interval-upper-bounds intervals))))
+        (upper-bounds (apply vector-map min (map %%interval-upper-bounds intervals))))
     (and (%%vector-every < lower-bounds upper-bounds)
-	 (make-%%interval lower-bounds upper-bounds))))
+         (make-%%interval lower-bounds upper-bounds))))
 
 (define (interval-intersect interval1 #!optional (interval2 (macro-absent-obj)) #!rest intervals)
   (cond ((eq? interval2 (macro-absent-obj))
-	 (cond ((not (interval? interval1))
-		(error "interval-intersect: The argument is not an interval: " interval1))
-	       (else
-		interval1)))
-	(else
-	 (let ((intervals (cons interval1 (cons interval2 intervals))))
-	   (cond ((not (%%every interval? intervals))
-		  (apply error "interval-intersect: Not all arguments are intervals: " intervals))
-		 ((not (apply = (map %%interval-dimension intervals)))
-		  (apply error "interval-intersect: Not all arguments have the same dimension: " intervals))
-		 (else
-		  (%%interval-intersect intervals)))))))
+         (cond ((not (interval? interval1))
+                (error "interval-intersect: The argument is not an interval: " interval1))
+               (else
+                interval1)))
+        (else
+         (let ((intervals (cons interval1 (cons interval2 intervals))))
+           (cond ((not (%%every interval? intervals))
+                  (apply error "interval-intersect: Not all arguments are intervals: " intervals))
+                 ((not (apply = (map %%interval-dimension intervals)))
+                  (apply error "interval-intersect: Not all arguments have the same dimension: " intervals))
+                 (else
+                  (%%interval-intersect intervals)))))))
 
 (declare (inline))
 
@@ -491,13 +460,13 @@
 
 (define (%%interval-contains-multi-index?-general interval multi-index)
   (let loop ((i 0)
-	     (multi-index multi-index))
+             (multi-index multi-index))
     (or (null? multi-index)
-	(let ((component (car multi-index)))
-	  (and (<= (%%interval-lower-bound interval i) component)
-	       (< component (%%interval-upper-bound interval i))
-	       (loop (+ i 1)
-		     (cdr multi-index)))))))
+        (let ((component (car multi-index)))
+          (and (<= (%%interval-lower-bound interval i) component)
+               (< component (%%interval-upper-bound interval i))
+               (loop (+ i 1)
+                     (cdr multi-index)))))))
 
 (define (interval-contains-multi-index? interval i #!rest multi-index-tail)
 
@@ -505,93 +474,93 @@
   ;; significantly simplifies testing the error checking
 
   (cond ((not (interval? interval))
-	 (error "interval-contains-multi-index?: The first argument is not an interval: " interval))
-	(else
-	 (let ((multi-index (cons i multi-index-tail)))
-	   (cond ((not (= (%%interval-dimension interval)
-			  (length multi-index)))
-		  (apply error "interval-contains-multi-index?: The dimension of the first argument (an interval) does not match number of indices: " interval multi-index))
-		 ((not (%%every exact-integer? multi-index))
-		  (apply error "interval-contains-multi-index?: At least one multi-index component is not an exact integer: " interval multi-index))
-		 (else
-		  (%%interval-contains-multi-index?-general interval multi-index)))))))
+         (error "interval-contains-multi-index?: The first argument is not an interval: " interval))
+        (else
+         (let ((multi-index (cons i multi-index-tail)))
+           (cond ((not (= (%%interval-dimension interval)
+                          (length multi-index)))
+                  (apply error "interval-contains-multi-index?: The dimension of the first argument (an interval) does not match number of indices: " interval multi-index))
+                 ((not (%%every exact-integer? multi-index))
+                  (apply error "interval-contains-multi-index?: At least one multi-index component is not an exact integer: " interval multi-index))
+                 (else
+                  (%%interval-contains-multi-index?-general interval multi-index)))))))
 
 ;;; Applies f to every element of the domain; assumes that f is thread-safe,
 ;;; the order of application is not specified
 
 (define (interval-for-each f interval)
   (cond ((not (interval? interval))
-	 (error "interval-for-each: The second argument is not a interval: " interval))
-	((not (procedure? f))
-	 (error "interval-for-each: The first argument is not a procedure: " f))
-	(else
-	 (%%interval-for-each f interval))))
+         (error "interval-for-each: The second argument is not a interval: " interval))
+        ((not (procedure? f))
+         (error "interval-for-each: The first argument is not a procedure: " f))
+        (else
+         (%%interval-for-each f interval))))
 
 (define (%%interval-for-each f interval)
   (case (%%interval-dimension interval)
     ((1) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (upper-i (%%interval-upper-bound interval 0)))
-	   (let i-loop ((i lower-i))
-	     (if (< i upper-i)
-		 (begin
-		   (f i)
-		   (i-loop (+ i 1)))))))
+               (upper-i (%%interval-upper-bound interval 0)))
+           (let i-loop ((i lower-i))
+             (if (< i upper-i)
+                 (begin
+                   (f i)
+                   (i-loop (+ i 1)))))))
     ((2) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (lower-j (%%interval-lower-bound interval 1))
-	       (upper-i (%%interval-upper-bound interval 0))
-	       (upper-j (%%interval-upper-bound interval 1)))
-	   (let i-loop ((i lower-i))
-	     (if (< i upper-i)
-		 (let j-loop ((j lower-j))
-		   (if (< j upper-j)
-		       (begin
-			 (f i j)
-			 (j-loop (+ j 1)))
-		       (i-loop (+ i 1))))))))
+               (lower-j (%%interval-lower-bound interval 1))
+               (upper-i (%%interval-upper-bound interval 0))
+               (upper-j (%%interval-upper-bound interval 1)))
+           (let i-loop ((i lower-i))
+             (if (< i upper-i)
+                 (let j-loop ((j lower-j))
+                   (if (< j upper-j)
+                       (begin
+                         (f i j)
+                         (j-loop (+ j 1)))
+                       (i-loop (+ i 1))))))))
     ((3) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (lower-j (%%interval-lower-bound interval 1))
-	       (lower-k (%%interval-lower-bound interval 2))
-	       (upper-i (%%interval-upper-bound interval 0))
-	       (upper-j (%%interval-upper-bound interval 1))
-	       (upper-k (%%interval-upper-bound interval 2)))
-	   (let i-loop ((i lower-i))
-	     (if (< i upper-i)
-		 (let j-loop ((j lower-j))
-		   (if (< j upper-j)
-		       (let k-loop ((k lower-k))
-			 (if (< k upper-k)
-			     (begin
-			       (f i j k)
-			       (k-loop (+ k 1)))
-			     (j-loop (+ j 1))))
-		       (i-loop (+ i 1))))))))
+               (lower-j (%%interval-lower-bound interval 1))
+               (lower-k (%%interval-lower-bound interval 2))
+               (upper-i (%%interval-upper-bound interval 0))
+               (upper-j (%%interval-upper-bound interval 1))
+               (upper-k (%%interval-upper-bound interval 2)))
+           (let i-loop ((i lower-i))
+             (if (< i upper-i)
+                 (let j-loop ((j lower-j))
+                   (if (< j upper-j)
+                       (let k-loop ((k lower-k))
+                         (if (< k upper-k)
+                             (begin
+                               (f i j k)
+                               (k-loop (+ k 1)))
+                             (j-loop (+ j 1))))
+                       (i-loop (+ i 1))))))))
     ((4) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (lower-j (%%interval-lower-bound interval 1))
-	       (lower-k (%%interval-lower-bound interval 2))
-	       (lower-l (%%interval-lower-bound interval 3))
-	       (upper-i (%%interval-upper-bound interval 0))
-	       (upper-j (%%interval-upper-bound interval 1))
-	       (upper-k (%%interval-upper-bound interval 2))
-	       (upper-l (%%interval-upper-bound interval 3)))
-	   (let i-loop ((i lower-i))
-	     (if (< i upper-i)
-		 (let j-loop ((j lower-j))
-		   (if (< j upper-j)
-		       (let k-loop ((k lower-k))
-			 (if (< k upper-k)
-			     (let l-loop ((l lower-l))
-			       (if (< l upper-l)
-				   (begin
-				     (f i j k l)
-				     (l-loop (+ l 1)))
-				   (k-loop (+ k 1))))
-			     (j-loop (+ j 1))))
-		       (i-loop (+ i 1))))))))
+               (lower-j (%%interval-lower-bound interval 1))
+               (lower-k (%%interval-lower-bound interval 2))
+               (lower-l (%%interval-lower-bound interval 3))
+               (upper-i (%%interval-upper-bound interval 0))
+               (upper-j (%%interval-upper-bound interval 1))
+               (upper-k (%%interval-upper-bound interval 2))
+               (upper-l (%%interval-upper-bound interval 3)))
+           (let i-loop ((i lower-i))
+             (if (< i upper-i)
+                 (let j-loop ((j lower-j))
+                   (if (< j upper-j)
+                       (let k-loop ((k lower-k))
+                         (if (< k upper-k)
+                             (let l-loop ((l lower-l))
+                               (if (< l upper-l)
+                                   (begin
+                                     (f i j k l)
+                                     (l-loop (+ l 1)))
+                                   (k-loop (+ k 1))))
+                             (j-loop (+ j 1))))
+                       (i-loop (+ i 1))))))))
     (else
 
      (let* ((lower-bounds (%%interval-lower-bounds->list interval))
-	    (upper-bounds (%%interval-upper-bounds->list interval))
-	    (arg          (map values lower-bounds)))                ; copy lower-bounds
+            (upper-bounds (%%interval-upper-bounds->list interval))
+            (arg          (map values lower-bounds)))                ; copy lower-bounds
 
        ;; I'm not particularly happy with set! here because f might capture the continuation
        ;; and then funny things might pursue ...
@@ -600,29 +569,29 @@
        ;; blah
 
        (define (iterate lower-bounds-tail
-			upper-bounds-tail
-			arg-tail)
-	 (let ((lower-bound (car lower-bounds-tail))
-	       (upper-bound (car upper-bounds-tail)))
-	   (if (null? (cdr arg-tail))
-	       (let loop ((i lower-bound))
-		 (if (< i upper-bound)
-		     (begin
-		       (set-car! arg-tail i)
-		       (apply f arg)
-		       (loop (+ i 1)))))
-	       (let loop ((i lower-bound))
-		 (if (< i upper-bound)
-		     (begin
-		       (set-car! arg-tail i)
-		       (iterate (cdr lower-bounds-tail)
-				(cdr upper-bounds-tail)
-				(cdr arg-tail))
-		       (loop (+ i 1))))))))
+                        upper-bounds-tail
+                        arg-tail)
+         (let ((lower-bound (car lower-bounds-tail))
+               (upper-bound (car upper-bounds-tail)))
+           (if (null? (cdr arg-tail))
+               (let loop ((i lower-bound))
+                 (if (< i upper-bound)
+                     (begin
+                       (set-car! arg-tail i)
+                       (apply f arg)
+                       (loop (+ i 1)))))
+               (let loop ((i lower-bound))
+                 (if (< i upper-bound)
+                     (begin
+                       (set-car! arg-tail i)
+                       (iterate (cdr lower-bounds-tail)
+                                (cdr upper-bounds-tail)
+                                (cdr arg-tail))
+                       (loop (+ i 1))))))))
 
        (iterate lower-bounds
-		upper-bounds
-		arg)))))
+                upper-bounds
+                arg)))))
 
 ;;; Calculates
 ;;;
@@ -635,63 +604,63 @@
 (define (%%interval-fold f operator identity interval)
   (case (%%interval-dimension interval)
     ((1) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (upper-i (%%interval-upper-bound interval 0)))
-	   (let i-loop ((i lower-i) (result identity))
-	     (if (= i upper-i)
-		 result
-		 (i-loop (+ i 1) (operator (f i) result))))))
+               (upper-i (%%interval-upper-bound interval 0)))
+           (let i-loop ((i lower-i) (result identity))
+             (if (= i upper-i)
+                 result
+                 (i-loop (+ i 1) (operator (f i) result))))))
     ((2) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (lower-j (%%interval-lower-bound interval 1))
-	       (upper-i (%%interval-upper-bound interval 0))
-	       (upper-j (%%interval-upper-bound interval 1)))
-	   (let i-loop ((i lower-i) (result identity))
-	     (if (= i upper-i)
-		 result
-		 (let j-loop ((j lower-j) (result result))
-		   (if (= j upper-j)
-		       (i-loop (+ i 1) result)
-		       (j-loop (+ j 1) (operator (f i j) result))))))))
+               (lower-j (%%interval-lower-bound interval 1))
+               (upper-i (%%interval-upper-bound interval 0))
+               (upper-j (%%interval-upper-bound interval 1)))
+           (let i-loop ((i lower-i) (result identity))
+             (if (= i upper-i)
+                 result
+                 (let j-loop ((j lower-j) (result result))
+                   (if (= j upper-j)
+                       (i-loop (+ i 1) result)
+                       (j-loop (+ j 1) (operator (f i j) result))))))))
     ((3) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (lower-j (%%interval-lower-bound interval 1))
-	       (lower-k (%%interval-lower-bound interval 2))
-	       (upper-i (%%interval-upper-bound interval 0))
-	       (upper-j (%%interval-upper-bound interval 1))
-	       (upper-k (%%interval-upper-bound interval 2)))
-	   (let i-loop ((i lower-i) (result identity))
-	     (if (= i upper-i)
-		 result
-		 (let j-loop ((j lower-j) (result result))
-		   (if (= j upper-j)
-		       (i-loop (+ i 1) result)
-		       (let k-loop ((k lower-k) (result result))
-			 (if (= k upper-k)
-			     (j-loop (+ j 1) result)
-			     (k-loop (+ k 1) (operator (f i j k) result))))))))))
+               (lower-j (%%interval-lower-bound interval 1))
+               (lower-k (%%interval-lower-bound interval 2))
+               (upper-i (%%interval-upper-bound interval 0))
+               (upper-j (%%interval-upper-bound interval 1))
+               (upper-k (%%interval-upper-bound interval 2)))
+           (let i-loop ((i lower-i) (result identity))
+             (if (= i upper-i)
+                 result
+                 (let j-loop ((j lower-j) (result result))
+                   (if (= j upper-j)
+                       (i-loop (+ i 1) result)
+                       (let k-loop ((k lower-k) (result result))
+                         (if (= k upper-k)
+                             (j-loop (+ j 1) result)
+                             (k-loop (+ k 1) (operator (f i j k) result))))))))))
     ((4) (let ((lower-i (%%interval-lower-bound interval 0))
-	       (lower-j (%%interval-lower-bound interval 1))
-	       (lower-k (%%interval-lower-bound interval 2))
-	       (lower-l (%%interval-lower-bound interval 3))
-	       (upper-i (%%interval-upper-bound interval 0))
-	       (upper-j (%%interval-upper-bound interval 1))
-	       (upper-k (%%interval-upper-bound interval 2))
-	       (upper-l (%%interval-upper-bound interval 3)))
-	   (let i-loop ((i lower-i) (result identity))
-	     (if (= i upper-i)
-		 result
-		 (let j-loop ((j lower-j) (result result))
-		   (if (= j upper-j)
-		       (i-loop (+ i 1) result)
-		       (let k-loop ((k lower-k) (result result))
-			 (if (= k upper-k)
-			     (j-loop (+ j 1) result)
-			     (let l-loop ((l lower-l) (result result))
-			       (if (= l upper-l)
-				   (k-loop (+ k 1) result)
-				   (l-loop (+ l 1) (operator (f i j k l) result))))))))))))
+               (lower-j (%%interval-lower-bound interval 1))
+               (lower-k (%%interval-lower-bound interval 2))
+               (lower-l (%%interval-lower-bound interval 3))
+               (upper-i (%%interval-upper-bound interval 0))
+               (upper-j (%%interval-upper-bound interval 1))
+               (upper-k (%%interval-upper-bound interval 2))
+               (upper-l (%%interval-upper-bound interval 3)))
+           (let i-loop ((i lower-i) (result identity))
+             (if (= i upper-i)
+                 result
+                 (let j-loop ((j lower-j) (result result))
+                   (if (= j upper-j)
+                       (i-loop (+ i 1) result)
+                       (let k-loop ((k lower-k) (result result))
+                         (if (= k upper-k)
+                             (j-loop (+ j 1) result)
+                             (let l-loop ((l lower-l) (result result))
+                               (if (= l upper-l)
+                                   (k-loop (+ k 1) result)
+                                   (l-loop (+ l 1) (operator (f i j k l) result))))))))))))
     (else
      (let* ((lower-bounds (%%interval-lower-bounds->list interval))
-	    (upper-bounds (%%interval-upper-bounds->list interval))
-	    (arg          (map values lower-bounds)))                ; copy lower-bounds
+            (upper-bounds (%%interval-upper-bounds->list interval))
+            (arg          (map values lower-bounds)))                ; copy lower-bounds
 
        ;; I'm not particularly happy with set! here because f or operator might capture
        ;; the continuation and then funny things might pursue ...
@@ -700,36 +669,36 @@
        ;; blah
 
        (define (iterate lower-bounds-tail
-			upper-bounds-tail
-			arg-tail
-			result)
-	 (let ((lower-bound (car lower-bounds-tail))
-	       (upper-bound (car upper-bounds-tail)))
-	   (if (null? (cdr arg-tail))
-	       (let loop ((i lower-bound)
-			  (result result))
-		 (if (= i upper-bound)
-		     result
-		     (begin
-		       (set-car! arg-tail i)
-		       (loop (+ i 1)
-			     (operator (apply f arg) result)))))
-	       (let loop ((i lower-bound)
-			  (result result))
-		 (if (= i upper-bound)
-		     result
-		     (begin
-		       (set-car! arg-tail i)
-		       (loop (+ i 1)
-			     (iterate (cdr lower-bounds-tail)
-				      (cdr upper-bounds-tail)
-				      (cdr arg-tail)
-				      result))))))))
+                        upper-bounds-tail
+                        arg-tail
+                        result)
+         (let ((lower-bound (car lower-bounds-tail))
+               (upper-bound (car upper-bounds-tail)))
+           (if (null? (cdr arg-tail))
+               (let loop ((i lower-bound)
+                          (result result))
+                 (if (= i upper-bound)
+                     result
+                     (begin
+                       (set-car! arg-tail i)
+                       (loop (+ i 1)
+                             (operator (apply f arg) result)))))
+               (let loop ((i lower-bound)
+                          (result result))
+                 (if (= i upper-bound)
+                     result
+                     (begin
+                       (set-car! arg-tail i)
+                       (loop (+ i 1)
+                             (iterate (cdr lower-bounds-tail)
+                                      (cdr upper-bounds-tail)
+                                      (cdr arg-tail)
+                                      result))))))))
 
        (iterate lower-bounds
-		upper-bounds
-		arg
-		identity)))))
+                upper-bounds
+                arg
+                identity)))))
 
 ;; We'll use the same basic container for all types of arrays.
 
@@ -752,21 +721,21 @@
   (let ((%%specialized-array-default-safe? #f))
     (lambda (#!optional (bool (macro-absent-obj)))
       (cond ((eq? bool (macro-absent-obj))
-	     %%specialized-array-default-safe?)
-	    ((not (boolean? bool))
-	     (error "specialized-array-default-safe?: The argument is not a boolean: " bool))
-	    (else
-	     (set! %%specialized-array-default-safe? bool))))))
+             %%specialized-array-default-safe?)
+            ((not (boolean? bool))
+             (error "specialized-array-default-safe?: The argument is not a boolean: " bool))
+            (else
+             (set! %%specialized-array-default-safe? bool))))))
 
 (define specialized-array-default-mutable?
   (let ((%%specialized-array-default-mutable? #t))
     (lambda (#!optional (bool (macro-absent-obj)))
       (cond ((eq? bool (macro-absent-obj))
-	     %%specialized-array-default-mutable?)
-	    ((not (boolean? bool))
-	     (error "specialized-array-default-mutable?: The argument is not a boolean: " bool))
-	    (else
-	     (set! %%specialized-array-default-mutable? bool))))))
+             %%specialized-array-default-mutable?)
+            ((not (boolean? bool))
+             (error "specialized-array-default-mutable?: The argument is not a boolean: " bool))
+            (else
+             (set! %%specialized-array-default-mutable? bool))))))
 
 
 (declare (not inline))
@@ -776,17 +745,17 @@
 
 (define (make-array domain getter #!optional (setter (macro-absent-obj)))
   (let ((setter (cond ((eq? setter (macro-absent-obj))
-		       #f)
-		      ((procedure? setter)
-		       setter)
-		      (else
-		       (error "make-array: The third argument is not a procedure: " domain getter setter)))))
+                       #f)
+                      ((procedure? setter)
+                       setter)
+                      (else
+                       (error "make-array: The third argument is not a procedure: " domain getter setter)))))
     (cond ((not (interval? domain))
-	   (error "make-array: The first argument is not an interval: " domain getter setter))
-	  ((not (procedure? getter))
-	   (error "make-array: The second argument is not a procedure: " domain getter setter))
-	  (else
-	   (make-%%array domain
+           (error "make-array: The first argument is not an interval: " domain getter setter))
+          ((not (procedure? getter))
+           (error "make-array: The second argument is not a procedure: " domain getter setter))
+          (else
+           (make-%%array domain
                          getter
                          setter
                          #f        ; storage-class
@@ -800,24 +769,24 @@
 
 (define (array-domain obj)
   (cond ((not (array? obj))
-	 (error "array-domain: The argument is not an array: " obj))
-	(else
-	 (%%array-domain obj))))
+         (error "array-domain: The argument is not an array: " obj))
+        (else
+         (%%array-domain obj))))
 
 (define (array-getter obj)
   (cond ((not (array? obj))
-	 (error "array-getter: The argument is not an array: " obj))
-	(else
-	 (%%array-getter obj))))
+         (error "array-getter: The argument is not an array: " obj))
+        (else
+         (%%array-getter obj))))
 
 (define (%%array-dimension array)
   (%%interval-dimension (%%array-domain array)))
 
 (define (array-dimension array)
   (cond ((not (array? array))
-	 (error "array-dimension: The argument is not an array: " array))
-	(else
-	 (%%array-dimension array))))
+         (error "array-dimension: The argument is not an array: " array))
+        (else
+         (%%array-dimension array))))
 
 
 ;;;
@@ -848,9 +817,9 @@
 
 (define (array-setter obj)
   (cond ((not (mutable-array? obj))
-	 (error "array-setter: The argument is not an mutable array: " obj))
-	(else
-	 (%%array-setter obj))))
+         (error "array-setter: The argument is not an mutable array: " obj))
+        (else
+         (%%array-setter obj))))
 
 ;;;
 ;;; A storage-class contains functions and objects to manipulate the
@@ -880,82 +849,82 @@
 
   (define (symbol-concatenate . symbols)
     (string->symbol (apply string-append (map (lambda (s)
-						(if (string? s)
-						    s
-						    (symbol->string s)))
-					      symbols))))
+                                                (if (string? s)
+                                                    s
+                                                    (symbol->string s)))
+                                              symbols))))
 
   `(begin
      ,@(map (lambda (name prefix default checker)
-	      `(define ,(symbol-concatenate name '-storage-class)
-		 (make-storage-class
-		  ;; getter:
-		  (lambda (v i)
-		    (,(symbol-concatenate prefix 'vector-ref) v i))
-		  ;; setter:
-		  (lambda (v i val)
-		    (,(symbol-concatenate prefix 'vector-set!) v i val))
-		  ;; checker
-		  ,checker
-		  ;; maker:
-		  ,(symbol-concatenate 'make- prefix 'vector)
+              `(define ,(symbol-concatenate name '-storage-class)
+                 (make-storage-class
+                  ;; getter:
+                  (lambda (v i)
+                    (,(symbol-concatenate prefix 'vector-ref) v i))
+                  ;; setter:
+                  (lambda (v i val)
+                    (,(symbol-concatenate prefix 'vector-set!) v i val))
+                  ;; checker
+                  ,checker
+                  ;; maker:
+                  ,(symbol-concatenate 'make- prefix 'vector)
                   ;; copier
                   ,(symbol-concatenate prefix 'vector-copy!)
-		  ;; length:
-		  ,(symbol-concatenate prefix 'vector-length)
-		  ;; default:
-		  ,default)))
-	    '(generic s8 u8 s16 u16 s32 u32 s64 u64 f32 f64)
-	    '(""      s8 u8 s16 u16 s32 u32 s64 u64 f32 f64)
-	    '(#f       0  0   0   0   0   0   0   0 0.0 0.0)
-	    `((lambda (x) #t)                             ; generic
-	      (lambda (x)                                 ; s8
-		(and (fixnum? x)
-		     (fx<= ,(- (expt 2 7))
-			   x
-			   ,(- (expt 2 7) 1))))
-	      (lambda (x)                                ; u8
-		(and (fixnum? x)
-		     (fx<= 0
-			   x
-			   ,(- (expt 2 8) 1))))
-	      (lambda (x)                               ; s16
-		(and (fixnum? x)
-		     (fx<= ,(- (expt 2 15))
-			   x
-			   ,(- (expt 2 15) 1))))
-	      (lambda (x)                               ; u16
-		(and (fixnum? x)
-		     (fx<= 0
-			   x
-			   ,(- (expt 2 16) 1))))
-	      (lambda (x)                               ; s32
-		(declare (generic))
-		(and (exact-integer? x)
-		     (<= ,(- (expt 2 31))
-			 x
-			 ,(- (expt 2 31) 1))))
-	      (lambda (x)                               ; u32
-		(declare (generic))
-		(and (exact-integer? x)
-		     (<= 0
-			 x
-			 ,(- (expt 2 32) 1))))
-	      (lambda (x)                              ; s64
-		(declare (generic))
-		(and (exact-integer? x)
-		     (<= ,(- (expt 2 63))
-			 x
-			 ,(- (expt 2 63) 1))))
-	      (lambda (x)                              ; u64
-		(declare (generic))
-		(and (exact-integer? x)
-		     (<= 0
-			 x
-			 ,(- (expt 2 64) 1))))
-	      (lambda (x) (flonum? x))               ; f32
-	      (lambda (x) (flonum? x))               ; f64
-	      ))))
+                  ;; length:
+                  ,(symbol-concatenate prefix 'vector-length)
+                  ;; default:
+                  ,default)))
+            '(generic s8 u8 s16 u16 s32 u32 s64 u64 f32 f64)
+            '(""      s8 u8 s16 u16 s32 u32 s64 u64 f32 f64)
+            '(#f       0  0   0   0   0   0   0   0 0.0 0.0)
+            `((lambda (x) #t)                             ; generic
+              (lambda (x)                                 ; s8
+                (and (fixnum? x)
+                     (fx<= ,(- (expt 2 7))
+                           x
+                           ,(- (expt 2 7) 1))))
+              (lambda (x)                                ; u8
+                (and (fixnum? x)
+                     (fx<= 0
+                           x
+                           ,(- (expt 2 8) 1))))
+              (lambda (x)                               ; s16
+                (and (fixnum? x)
+                     (fx<= ,(- (expt 2 15))
+                           x
+                           ,(- (expt 2 15) 1))))
+              (lambda (x)                               ; u16
+                (and (fixnum? x)
+                     (fx<= 0
+                           x
+                           ,(- (expt 2 16) 1))))
+              (lambda (x)                               ; s32
+                (declare (generic))
+                (and (exact-integer? x)
+                     (<= ,(- (expt 2 31))
+                         x
+                         ,(- (expt 2 31) 1))))
+              (lambda (x)                               ; u32
+                (declare (generic))
+                (and (exact-integer? x)
+                     (<= 0
+                         x
+                         ,(- (expt 2 32) 1))))
+              (lambda (x)                              ; s64
+                (declare (generic))
+                (and (exact-integer? x)
+                     (<= ,(- (expt 2 63))
+                         x
+                         ,(- (expt 2 63) 1))))
+              (lambda (x)                              ; u64
+                (declare (generic))
+                (and (exact-integer? x)
+                     (<= 0
+                         x
+                         ,(- (expt 2 64) 1))))
+              (lambda (x) (flonum? x))               ; f32
+              (lambda (x) (flonum? x))               ; f64
+              ))))
 
 (make-standard-storage-classes)
 
@@ -972,25 +941,25 @@
    ;; getter:
    (lambda (v i)
      (let ((index (fxarithmetic-shift-right i 4))
-	   (shift (fxand i 15))
-	   (bodyv (vector-ref v  1)))
+           (shift (fxand i 15))
+           (bodyv (vector-ref v  1)))
        (fxand
-	(fxarithmetic-shift-right
-	 (u16vector-ref bodyv index)
-	 shift)
-	1)))
+        (fxarithmetic-shift-right
+         (u16vector-ref bodyv index)
+         shift)
+        1)))
    ;; setter:
    (lambda (v i val)
      (let ((index (fxarithmetic-shift-right i 4))
-	   (shift (fxand i 15))
-	   (bodyv (vector-ref v  1)))
+           (shift (fxand i 15))
+           (bodyv (vector-ref v  1)))
        (u16vector-set! bodyv index (fxior (fxarithmetic-shift-left val shift)
-					  (fxand (u16vector-ref bodyv index)
-						 (fxnot  (fxarithmetic-shift-left 1 shift)))))))
+                                          (fxand (u16vector-ref bodyv index)
+                                                 (fxnot  (fxarithmetic-shift-left 1 shift)))))))
    ;; checker
    (lambda (val)
      (and (fixnum? val)
-	  (eq? 0 (fxand -2 val))))
+          (eq? 0 (fxand -2 val))))
    ;; maker:
    (lambda (size initializer)
      (let ((u16-size (fxarithmetic-shift-right (+ size 15) 4)))
@@ -1006,53 +975,53 @@
 (define-macro (make-complex-storage-classes)
   (define (symbol-concatenate . symbols)
     (string->symbol (apply string-append (map (lambda (s)
-						(if (string? s)
-						    s
-						    (symbol->string s)))
-					      symbols))))
+                                                (if (string? s)
+                                                    s
+                                                    (symbol->string s)))
+                                              symbols))))
   (define construct
     (lambda (size)
       (let ((prefix (string-append "c" (number->string (fx* 2 size))))
-	    (floating-point-prefix (string-append "f" (number->string size))))
-	`(define ,(symbol-concatenate prefix '-storage-class)
-	   (make-storage-class
-	    ;; getter
-	    (lambda (body i)
-	      (make-rectangular (,(symbol-concatenate floating-point-prefix 'vector-ref) body (fx* 2 i))
-				(,(symbol-concatenate floating-point-prefix 'vector-ref) body (fx+ (fx* 2 i) 1))))
-	    ;; setter
-	    (lambda (body i obj)
-	      (,(symbol-concatenate floating-point-prefix 'vector-set!) body (fx* 2 i)         (real-part obj))
-	      (,(symbol-concatenate floating-point-prefix 'vector-set!) body (fx+ (fx* 2 i) 1) (imag-part obj)))
-	    ;; checker
-	    (lambda (obj)
-	      (and (complex? obj)
-		   (inexact? (real-part obj))
-		   (inexact? (imag-part obj))))
-	    ;; maker
-	    (lambda (n val)
-	      (let ((l (* 2 n))
-		    (re (real-part val))
-		    (im (imag-part val)))
-		(let ((result (,(symbol-concatenate 'make-
-						    floating-point-prefix
-						    'vector)
-			       l)))
-		  (do ((i 0 (+ i 2)))
-		      ((= i l) result)
-		    (,(symbol-concatenate floating-point-prefix 'vector-set!) result i re)
-		    (,(symbol-concatenate floating-point-prefix 'vector-set!) result (fx+ i 1) im)))))
+            (floating-point-prefix (string-append "f" (number->string size))))
+        `(define ,(symbol-concatenate prefix '-storage-class)
+           (make-storage-class
+            ;; getter
+            (lambda (body i)
+              (make-rectangular (,(symbol-concatenate floating-point-prefix 'vector-ref) body (fx* 2 i))
+                                (,(symbol-concatenate floating-point-prefix 'vector-ref) body (fx+ (fx* 2 i) 1))))
+            ;; setter
+            (lambda (body i obj)
+              (,(symbol-concatenate floating-point-prefix 'vector-set!) body (fx* 2 i)         (real-part obj))
+              (,(symbol-concatenate floating-point-prefix 'vector-set!) body (fx+ (fx* 2 i) 1) (imag-part obj)))
+            ;; checker
+            (lambda (obj)
+              (and (complex? obj)
+                   (inexact? (real-part obj))
+                   (inexact? (imag-part obj))))
+            ;; maker
+            (lambda (n val)
+              (let ((l (* 2 n))
+                    (re (real-part val))
+                    (im (imag-part val)))
+                (let ((result (,(symbol-concatenate 'make-
+                                                    floating-point-prefix
+                                                    'vector)
+                               l)))
+                  (do ((i 0 (+ i 2)))
+                      ((= i l) result)
+                    (,(symbol-concatenate floating-point-prefix 'vector-set!) result i re)
+                    (,(symbol-concatenate floating-point-prefix 'vector-set!) result (fx+ i 1) im)))))
             ;; copier
             ,(symbol-concatenate prefix 'vector-copy!)
-	    ;; length
-	    (lambda (body)
-	      (fxquotient (,(symbol-concatenate floating-point-prefix 'vector-length) body) 2))
-	    ;; default
-	    0.+0.i)))))
+            ;; length
+            (lambda (body)
+              (fxquotient (,(symbol-concatenate floating-point-prefix 'vector-length) body) 2))
+            ;; default
+            0.+0.i)))))
   (let ((result
-	 `(begin
-	    ,@(map construct
-		   '(32 64)))))
+         `(begin
+            ,@(map construct
+                   '(32 64)))))
     result))
 
 (make-complex-storage-classes)
@@ -1078,241 +1047,241 @@
 ;; unfortunately, the next two functions were written by hand, so beware of bugs.
 
 (define (%%indexer-1 base
-		     low-0
-		     increment-0)
+                     low-0
+                     increment-0)
   (if (zero? base)
       (if (zero? low-0)
-	  (cond ((= 1 increment-0)    (lambda (i) i))
-		;;((= -1 increment-0)   (lambda (i) (- i)))               ;; an impossible case
-		(else                 (lambda (i) (* i increment-0))))
-	  (cond ((= 1 increment-0)    (lambda (i) (- i low-0)))
-		;;((= -1 increment-0)   (lambda (i) (- low-0 i)))         ;; an impossible case
-		(else                 (lambda (i) (* increment-0 (- i low-0))))))
+          (cond ((= 1 increment-0)    (lambda (i) i))
+                ;;((= -1 increment-0)   (lambda (i) (- i)))               ;; an impossible case
+                (else                 (lambda (i) (* i increment-0))))
+          (cond ((= 1 increment-0)    (lambda (i) (- i low-0)))
+                ;;((= -1 increment-0)   (lambda (i) (- low-0 i)))         ;; an impossible case
+                (else                 (lambda (i) (* increment-0 (- i low-0))))))
       (if (zero? low-0)
-	  (cond ((= 1 increment-0)    (lambda (i) (+ base i)))
-		((= -1 increment-0)   (lambda (i) (- base i)))
-		(else                 (lambda (i) (+ base (* increment-0 i)))))
-	  (cond ((= 1 increment-0)    (lambda (i) (+ base (- i low-0))))
-		((= -1 increment-0)   (lambda (i) (+ base (- low-0 i))))
-		(else                 (lambda (i) (+ base (* increment-0 (- i low-0)))))))))
+          (cond ((= 1 increment-0)    (lambda (i) (+ base i)))
+                ((= -1 increment-0)   (lambda (i) (- base i)))
+                (else                 (lambda (i) (+ base (* increment-0 i)))))
+          (cond ((= 1 increment-0)    (lambda (i) (+ base (- i low-0))))
+                ((= -1 increment-0)   (lambda (i) (+ base (- low-0 i))))
+                (else                 (lambda (i) (+ base (* increment-0 (- i low-0)))))))))
 
 (define (%%indexer-2 base
-		     low-0       low-1
-		     increment-0 increment-1)
+                     low-0       low-1
+                     increment-0 increment-1)
   (if (zero? base)
       (if (zero? low-0)
-	  (cond ((= 1 increment-0)
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ i j)))
-			   ((= -1 increment-1)   (lambda (i j) (+ i (- j))))
-			   (else                 (lambda (i j) (+ i (* increment-1 j)))))
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ i (- j low-1))))
-			   ((= -1 increment-1)   (lambda (i j) (+ i (- low-1 j))))
-			   (else                 (lambda (i j) (+ i (* increment-1 (- j low-1))))))))
-		#;((= -1 increment-0)         ;; an impossible case
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (- j                           i)))
-			   ((= -1 increment-1)  (lambda (i j) (- (- j)                       i)))
-			   (else                (lambda (i j) (- (* increment-1 j)           i))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (- (- j low-1)                 i)))
-			   ((= -1 increment-1)  (lambda (i j) (- (- low-1 j)                 i)))
-			   (else                (lambda (i j) (- (* increment-1 (- j low-1)) i))))))
-		(else
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 i) j)))
-			   ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 i) (- j))))
-			   (else                (lambda (i j) (+ (* increment-0 i) (* increment-1 j)))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 i) (- j low-1))))
-			   ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 i) (- low-1 j))))
-			   (else                (lambda (i j) (+ (* increment-0 i) (* increment-1 (- j low-1)))))))))
-	  (cond ((= 1 increment-0)
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ (- i low-0) j)))
-			   ((= -1 increment-1)   (lambda (i j) (+ (- i low-0) (- j))))
-			   (else                 (lambda (i j) (+ (- i low-0) (* increment-1 j)))))
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ (- i low-0) (- j low-1))))
-			   ((= -1 increment-1)   (lambda (i j) (+ (- i low-0) (- low-1 j))))
-			   (else                 (lambda (i j) (+ (- i low-0) (* increment-1 (- j low-1))))))))
-		#;((= -1 increment-0)         ;; an impossible case
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (- j                           (- i low-0))))
-			   ((= -1 increment-1)  (lambda (i j) (- (- j)                       (- i low-0))))
-			   (else                (lambda (i j) (- (* increment-1 j)           (- i low-0)))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (- (- j low-1)                 (- i low-0))))
-			   ((= -1 increment-1)  (lambda (i j) (- (- low-1 j)                 (- i low-0))))
-			   (else                (lambda (i j) (- (* increment-1 (- j low-1)) (- i low-0)))))))
-		(else
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 (- i low-0)) j)))
-			   ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 (- i low-0)) (- j))))
-			   (else                (lambda (i j) (+ (* increment-0 (- i low-0)) (* increment-1 j)))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 (- i low-0)) (- j low-1))))
-			   ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 (- i low-0)) (- low-1 j))))
-			   (else                (lambda (i j) (+ (* increment-0 (- i low-0)) (* increment-1 (- j low-1))))))))))
+          (cond ((= 1 increment-0)
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ i j)))
+                           ((= -1 increment-1)   (lambda (i j) (+ i (- j))))
+                           (else                 (lambda (i j) (+ i (* increment-1 j)))))
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ i (- j low-1))))
+                           ((= -1 increment-1)   (lambda (i j) (+ i (- low-1 j))))
+                           (else                 (lambda (i j) (+ i (* increment-1 (- j low-1))))))))
+               #; ((= -1 increment-0)         ;; an impossible case
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (- j                           i)))
+                           ((= -1 increment-1)  (lambda (i j) (- (- j)                       i)))
+                           (else                (lambda (i j) (- (* increment-1 j)           i))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (- (- j low-1)                 i)))
+                           ((= -1 increment-1)  (lambda (i j) (- (- low-1 j)                 i)))
+                           (else                (lambda (i j) (- (* increment-1 (- j low-1)) i))))))
+                (else
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 i) j)))
+                           ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 i) (- j))))
+                           (else                (lambda (i j) (+ (* increment-0 i) (* increment-1 j)))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 i) (- j low-1))))
+                           ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 i) (- low-1 j))))
+                           (else                (lambda (i j) (+ (* increment-0 i) (* increment-1 (- j low-1)))))))))
+          (cond ((= 1 increment-0)
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ (- i low-0) j)))
+                           ((= -1 increment-1)   (lambda (i j) (+ (- i low-0) (- j))))
+                           (else                 (lambda (i j) (+ (- i low-0) (* increment-1 j)))))
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ (- i low-0) (- j low-1))))
+                           ((= -1 increment-1)   (lambda (i j) (+ (- i low-0) (- low-1 j))))
+                           (else                 (lambda (i j) (+ (- i low-0) (* increment-1 (- j low-1))))))))
+                #;((= -1 increment-0)         ;; an impossible case
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (- j                           (- i low-0))))
+                           ((= -1 increment-1)  (lambda (i j) (- (- j)                       (- i low-0))))
+                           (else                (lambda (i j) (- (* increment-1 j)           (- i low-0)))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (- (- j low-1)                 (- i low-0))))
+                           ((= -1 increment-1)  (lambda (i j) (- (- low-1 j)                 (- i low-0))))
+                           (else                (lambda (i j) (- (* increment-1 (- j low-1)) (- i low-0)))))))
+                (else
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 (- i low-0)) j)))
+                           ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 (- i low-0)) (- j))))
+                           (else                (lambda (i j) (+ (* increment-0 (- i low-0)) (* increment-1 j)))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ (* increment-0 (- i low-0)) (- j low-1))))
+                           ((= -1 increment-1)  (lambda (i j) (+ (* increment-0 (- i low-0)) (- low-1 j))))
+                           (else                (lambda (i j) (+ (* increment-0 (- i low-0)) (* increment-1 (- j low-1))))))))))
       (if (zero? low-0)
-	  (cond ((= 1 increment-0)
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ base i j)))
-			   ((= -1 increment-1)   (lambda (i j) (+ base i (- j))))
-			   (else                 (lambda (i j) (+ base i (* increment-1 j)))))
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ base i (- j low-1))))
-			   ((= -1 increment-1)   (lambda (i j) (+ base i (- low-1 j))))
-			   (else                 (lambda (i j) (+ base i (* increment-1 (- j low-1))))))))
-		((= -1 increment-0)
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base j)                           i)))
-			   ((= -1 increment-1)  (lambda (i j) (- (- base j)                           i)))
-			   (else                (lambda (i j) (- (+ base (* increment-1 j))           i))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base (- j low-1))                 i)))
-			   ((= -1 increment-1)  (lambda (i j) (- (+ base (- low-1 j))                 i)))
-			   (else                (lambda (i j) (- (+ base (* increment-1 (- j low-1))) i))))))
-		(else
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 i) j)))
-			   ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 i) (- j))))
-			   (else                (lambda (i j) (+ base (* increment-0 i) (* increment-1 j)))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 i) (- j low-1))))
-			   ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 i) (- low-1 j))))
-			   (else                (lambda (i j) (+ base (* increment-0 i) (* increment-1 (- j low-1)))))))))
-	  (cond ((= 1 increment-0)
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ base (- i low-0) j)))
-			   ((= -1 increment-1)   (lambda (i j) (+ base (- i low-0) (- j))))
-			   (else                 (lambda (i j) (+ base (- i low-0) (* increment-1 j)))))
-		     (cond ((= 1 increment-1)    (lambda (i j) (+ base (- i low-0) (- j low-1))))
-			   ((= -1 increment-1)   (lambda (i j) (+ base (- i low-0) (- low-1 j))))
-			   (else                 (lambda (i j) (+ base (- i low-0) (* increment-1 (- j low-1))))))))
-		((= -1 increment-0)
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base j)                           (- i low-0))))
-			   ((= -1 increment-1)  (lambda (i j) (- (- base j)                           (- i low-0))))
-			   (else                (lambda (i j) (- (+ base (* increment-1 j))           (- i low-0)))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base (- j low-1))                 (- i low-0))))
-			   ((= -1 increment-1)  (lambda (i j) (- (+ base (- low-1 j))                 (- i low-0))))
-			   (else                (lambda (i j) (- (+ base (* increment-1 (- j low-1))) (- i low-0)))))))
-		(else
-		 (if (zero? low-1)
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 (- i low-0)) j)))
-			   ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 (- i low-0)) (- j))))
-			   (else                (lambda (i j) (+ base (* increment-0 (- i low-0)) (* increment-1 j)))))
-		     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 (- i low-0)) (- j low-1))))
-			   ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 (- i low-0)) (- low-1 j))))
-			   (else                (lambda (i j) (+ base (* increment-0 (- i low-0)) (* increment-1 (- j low-1))))))))))))
+          (cond ((= 1 increment-0)
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ base i j)))
+                           ((= -1 increment-1)   (lambda (i j) (+ base i (- j))))
+                           (else                 (lambda (i j) (+ base i (* increment-1 j)))))
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ base i (- j low-1))))
+                           ((= -1 increment-1)   (lambda (i j) (+ base i (- low-1 j))))
+                           (else                 (lambda (i j) (+ base i (* increment-1 (- j low-1))))))))
+                ((= -1 increment-0)
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base j)                           i)))
+                           ((= -1 increment-1)  (lambda (i j) (- (- base j)                           i)))
+                           (else                (lambda (i j) (- (+ base (* increment-1 j))           i))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base (- j low-1))                 i)))
+                           ((= -1 increment-1)  (lambda (i j) (- (+ base (- low-1 j))                 i)))
+                           (else                (lambda (i j) (- (+ base (* increment-1 (- j low-1))) i))))))
+                (else
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 i) j)))
+                           ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 i) (- j))))
+                           (else                (lambda (i j) (+ base (* increment-0 i) (* increment-1 j)))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 i) (- j low-1))))
+                           ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 i) (- low-1 j))))
+                           (else                (lambda (i j) (+ base (* increment-0 i) (* increment-1 (- j low-1)))))))))
+          (cond ((= 1 increment-0)
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ base (- i low-0) j)))
+                           ((= -1 increment-1)   (lambda (i j) (+ base (- i low-0) (- j))))
+                           (else                 (lambda (i j) (+ base (- i low-0) (* increment-1 j)))))
+                     (cond ((= 1 increment-1)    (lambda (i j) (+ base (- i low-0) (- j low-1))))
+                           ((= -1 increment-1)   (lambda (i j) (+ base (- i low-0) (- low-1 j))))
+                           (else                 (lambda (i j) (+ base (- i low-0) (* increment-1 (- j low-1))))))))
+                ((= -1 increment-0)
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base j)                           (- i low-0))))
+                           ((= -1 increment-1)  (lambda (i j) (- (- base j)                           (- i low-0))))
+                           (else                (lambda (i j) (- (+ base (* increment-1 j))           (- i low-0)))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (- (+ base (- j low-1))                 (- i low-0))))
+                           ((= -1 increment-1)  (lambda (i j) (- (+ base (- low-1 j))                 (- i low-0))))
+                           (else                (lambda (i j) (- (+ base (* increment-1 (- j low-1))) (- i low-0)))))))
+                (else
+                 (if (zero? low-1)
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 (- i low-0)) j)))
+                           ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 (- i low-0)) (- j))))
+                           (else                (lambda (i j) (+ base (* increment-0 (- i low-0)) (* increment-1 j)))))
+                     (cond ((= 1 increment-1)   (lambda (i j) (+ base (* increment-0 (- i low-0)) (- j low-1))))
+                           ((= -1 increment-1)  (lambda (i j) (+ base (* increment-0 (- i low-0)) (- low-1 j))))
+                           (else                (lambda (i j) (+ base (* increment-0 (- i low-0)) (* increment-1 (- j low-1))))))))))))
 
 ;;; after this we basically punt
 
 (define (%%indexer-3 base
-		     low-0       low-1       low-2
-		     increment-0 increment-1 increment-2)
+                     low-0       low-1       low-2
+                     increment-0 increment-1 increment-2)
   (if (= 0 low-0 low-1 low-2)
       (if (= base 0)
-	  (if (= increment-2 1)
-	      (lambda (i j k)
-		(+ (* increment-0 i)
-		   (* increment-1 j)
-		   k))
-	      (lambda (i j k)
-		(+ (* increment-0 i)
-		   (* increment-1 j)
-		   (* increment-2 k))))
-	  (if (= increment-2 1)
-	      (lambda (i j k)
-		(+ base
-		   (* increment-0 i)
-		   (* increment-1 j)
-		   k))
-	      (lambda (i j k)
-		(+ base
-		   (* increment-0 i)
-		   (* increment-1 j)
-		   (* increment-2 k)))))
+          (if (= increment-2 1)
+              (lambda (i j k)
+                (+ (* increment-0 i)
+                   (* increment-1 j)
+                   k))
+              (lambda (i j k)
+                (+ (* increment-0 i)
+                   (* increment-1 j)
+                   (* increment-2 k))))
+          (if (= increment-2 1)
+              (lambda (i j k)
+                (+ base
+                   (* increment-0 i)
+                   (* increment-1 j)
+                   k))
+              (lambda (i j k)
+                (+ base
+                   (* increment-0 i)
+                   (* increment-1 j)
+                   (* increment-2 k)))))
       (if (= base 0)
-	  (if (= increment-2 1)
-	      (lambda (i j k)
-		(+ (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (- k low-2)))
-	      (lambda (i j k)
-		(+ (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (* increment-2 (- k low-2)))))
-	  (if (= increment-2 1)
-	      (lambda (i j k)
-		(+ base
-		   (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (- k low-2)))
-	      (lambda (i j k)
-		(+ base
-		   (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (* increment-2 (- k low-2))))))))
+          (if (= increment-2 1)
+              (lambda (i j k)
+                (+ (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (- k low-2)))
+              (lambda (i j k)
+                (+ (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (* increment-2 (- k low-2)))))
+          (if (= increment-2 1)
+              (lambda (i j k)
+                (+ base
+                   (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (- k low-2)))
+              (lambda (i j k)
+                (+ base
+                   (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (* increment-2 (- k low-2))))))))
 
 (define (%%indexer-4 base
-		     low-0       low-1       low-2       low-3
-		     increment-0 increment-1 increment-2 increment-3)
+                     low-0       low-1       low-2       low-3
+                     increment-0 increment-1 increment-2 increment-3)
   (if (= 0 low-0 low-1 low-2 low-3)
       (if (= base 0)
-	  (if (= increment-3 1)
-	      (lambda (i j k l)
-		(+ (* increment-0 i)
-		   (* increment-1 j)
-		   (* increment-2 k)
-		   l))
-	      (lambda (i j k l)
-		(+ (* increment-0 i)
-		   (* increment-1 j)
-		   (* increment-2 k)
-		   (* increment-3 l))))
-	  (if (= increment-3 1)
-	      (lambda (i j k l)
-		(+ base
-		   (* increment-0 i)
-		   (* increment-1 j)
-		   (* increment-2 k)
-		   l))
-	      (lambda (i j k l)
-		(+ base
-		   (* increment-0 i)
-		   (* increment-1 j)
-		   (* increment-2 k)
-		   (* increment-3 l)))))
+          (if (= increment-3 1)
+              (lambda (i j k l)
+                (+ (* increment-0 i)
+                   (* increment-1 j)
+                   (* increment-2 k)
+                   l))
+              (lambda (i j k l)
+                (+ (* increment-0 i)
+                   (* increment-1 j)
+                   (* increment-2 k)
+                   (* increment-3 l))))
+          (if (= increment-3 1)
+              (lambda (i j k l)
+                (+ base
+                   (* increment-0 i)
+                   (* increment-1 j)
+                   (* increment-2 k)
+                   l))
+              (lambda (i j k l)
+                (+ base
+                   (* increment-0 i)
+                   (* increment-1 j)
+                   (* increment-2 k)
+                   (* increment-3 l)))))
       (if (= base 0)
-	  (if (= increment-3 1)
-	      (lambda (i j k l)
-		(+ (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (* increment-2 (- k low-2))
-		   (- l low-3)))
-	      (lambda (i j k l)
-		(+ (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (* increment-2 (- k low-2))
-		   (* increment-3 (- l low-3)))))
-	  (if (= increment-3 1)
-	      (lambda (i j k l)
-		(+ base
-		   (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (* increment-2 (- k low-2))
-		   (- l low-3)))
-	      (lambda (i j k l)
-		(+ base
-		   (* increment-0 (- i low-0))
-		   (* increment-1 (- j low-1))
-		   (* increment-2 (- k low-2))
-		   (* increment-3 (- l low-3))))))))
+          (if (= increment-3 1)
+              (lambda (i j k l)
+                (+ (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (* increment-2 (- k low-2))
+                   (- l low-3)))
+              (lambda (i j k l)
+                (+ (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (* increment-2 (- k low-2))
+                   (* increment-3 (- l low-3)))))
+          (if (= increment-3 1)
+              (lambda (i j k l)
+                (+ base
+                   (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (* increment-2 (- k low-2))
+                   (- l low-3)))
+              (lambda (i j k l)
+                (+ base
+                   (* increment-0 (- i low-0))
+                   (* increment-1 (- j low-1))
+                   (* increment-2 (- k low-2))
+                   (* increment-3 (- l low-3))))))))
 
 (define (%%indexer-generic base lower-bounds increments)
   (let ((result
-	 (lambda multi-index
-	   (do ((multi-index  multi-index  (cdr multi-index))
-		(lower-bounds lower-bounds (cdr lower-bounds))
-		(increments   increments   (cdr increments))
-		(result       base         (+ result (* (car increments)
-							(- (car multi-index)
-							   (car lower-bounds))))))
-	       ((null? multi-index) result)))))
+         (lambda multi-index
+           (do ((multi-index  multi-index  (cdr multi-index))
+                (lower-bounds lower-bounds (cdr lower-bounds))
+                (increments   increments   (cdr increments))
+                (result       base         (+ result (* (car increments)
+                                                        (- (car multi-index)
+                                                           (car lower-bounds))))))
+               ((null? multi-index) result)))))
     result))
 
 
@@ -1350,135 +1319,135 @@
 
 (define (array-body obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-body: The argument is not a specialized array: " obj))
-	(else
-	 (%%array-body obj))))
+         (error "array-body: The argument is not a specialized array: " obj))
+        (else
+         (%%array-body obj))))
 
 (define (array-indexer obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-indexer: The argument is not a specialized array: " obj))
-	(else
-	 (%%array-indexer obj))))
+         (error "array-indexer: The argument is not a specialized array: " obj))
+        (else
+         (%%array-indexer obj))))
 
 (define (array-storage-class obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-storage-class: The argument is not a specialized array: " obj))
-	(else
-	 (%%array-storage-class obj))))
+         (error "array-storage-class: The argument is not a specialized array: " obj))
+        (else
+         (%%array-storage-class obj))))
 
 (define (array-safe? obj)
   (cond ((not (specialized-array? obj))
-	 (error "array-safe?: The argument is not a specialized array: " obj))
-	(else
-	 (%%array-safe? obj))))
+         (error "array-safe?: The argument is not a specialized array: " obj))
+        (else
+         (%%array-safe? obj))))
 
 (define (%%array-elements-in-order? array)
   (let ((domain  (%%array-domain array))
         (indexer (%%array-indexer array)))
-  (case (%%interval-dimension domain)
-    ((1) (let ((lower-0 (%%interval-lower-bound domain 0))
-               (upper-0 (%%interval-upper-bound domain 0)))
-           (let ((increment 1))
-             (or (= 1 (- upper-0 lower-0))
-                 (= increment
-                    (- (indexer (+ lower-0 1))
-                       (indexer lower-0)))))))
-    ((2) (let ((lower-0 (%%interval-lower-bound domain 0))
-               (lower-1 (%%interval-lower-bound domain 1))
-               (upper-0 (%%interval-upper-bound domain 0))
-               (upper-1 (%%interval-upper-bound domain 1)))
-           (let ((increment 1))
-             (and (or (= 1 (- upper-1 lower-1))
-                      (= increment
-                         (- (indexer lower-0 (+ lower-1 1))
-                            (indexer lower-0    lower-1))))
-                  (let ((increment (* increment (- upper-1 lower-1))))
-                    (or (= 1 (- upper-0 lower-0))
+    (case (%%interval-dimension domain)
+      ((1) (let ((lower-0 (%%interval-lower-bound domain 0))
+                 (upper-0 (%%interval-upper-bound domain 0)))
+             (let ((increment 1))
+               (or (= 1 (- upper-0 lower-0))
+                   (= increment
+                      (- (indexer (+ lower-0 1))
+                         (indexer lower-0)))))))
+      ((2) (let ((lower-0 (%%interval-lower-bound domain 0))
+                 (lower-1 (%%interval-lower-bound domain 1))
+                 (upper-0 (%%interval-upper-bound domain 0))
+                 (upper-1 (%%interval-upper-bound domain 1)))
+             (let ((increment 1))
+               (and (or (= 1 (- upper-1 lower-1))
                         (= increment
-                           (- (indexer (+ lower-0 1) lower-1)
-                              (indexer    lower-0    lower-1)))))))))
-    ((3) (let ((lower-0 (%%interval-lower-bound domain 0))
-               (lower-1 (%%interval-lower-bound domain 1))
-               (lower-2 (%%interval-lower-bound domain 2))
-               (upper-0 (%%interval-upper-bound domain 0))
-               (upper-1 (%%interval-upper-bound domain 1))
-               (upper-2 (%%interval-upper-bound domain 2)))
-           (let ((increment 1))
-             (and (or (= 1 (- upper-2 lower-2))
-                      (= increment
-                         (- (indexer lower-0 lower-1 (+ lower-2 1))
-                            (indexer lower-0 lower-1    lower-2))))
-                  (let ((increment (* increment (- upper-2 lower-2))))
-                    (and (or (= 1 (- upper-1 lower-1))
-                             (= increment
-                                (- (indexer lower-0 (+ lower-1 1) lower-2)
-                                   (indexer lower-0    lower-1    lower-2))))
-                         (let ((increment (* increment (- upper-1 lower-1))))
-                           (or (= 1 (- upper-0 lower-0))
+                           (- (indexer lower-0 (+ lower-1 1))
+                              (indexer lower-0    lower-1))))
+                    (let ((increment (* increment (- upper-1 lower-1))))
+                      (or (= 1 (- upper-0 lower-0))
+                          (= increment
+                             (- (indexer (+ lower-0 1) lower-1)
+                                (indexer    lower-0    lower-1)))))))))
+      ((3) (let ((lower-0 (%%interval-lower-bound domain 0))
+                 (lower-1 (%%interval-lower-bound domain 1))
+                 (lower-2 (%%interval-lower-bound domain 2))
+                 (upper-0 (%%interval-upper-bound domain 0))
+                 (upper-1 (%%interval-upper-bound domain 1))
+                 (upper-2 (%%interval-upper-bound domain 2)))
+             (let ((increment 1))
+               (and (or (= 1 (- upper-2 lower-2))
+                        (= increment
+                           (- (indexer lower-0 lower-1 (+ lower-2 1))
+                              (indexer lower-0 lower-1    lower-2))))
+                    (let ((increment (* increment (- upper-2 lower-2))))
+                      (and (or (= 1 (- upper-1 lower-1))
                                (= increment
-                                  (- (indexer (+ lower-0 1) lower-1 lower-2)
-                                     (indexer    lower-0    lower-1 lower-2)))))))))))
-    ((4) (let ((lower-0 (%%interval-lower-bound domain 0))
-               (lower-1 (%%interval-lower-bound domain 1))
-               (lower-2 (%%interval-lower-bound domain 2))
-               (lower-3 (%%interval-lower-bound domain 3))
-               (upper-0 (%%interval-upper-bound domain 0))
-               (upper-1 (%%interval-upper-bound domain 1))
-               (upper-2 (%%interval-upper-bound domain 2))
-               (upper-3 (%%interval-upper-bound domain 3)))
-           (let ((increment 1))
-             (and (or (= 1 (- upper-3 lower-3))
-                      (= increment
-                         (- (indexer lower-0 lower-1 lower-2 (+ lower-3 1))
-                            (indexer lower-0 lower-1 lower-2    lower-3))))
-                  (let ((increment (* increment (- upper-3 lower-3))))
-                    (and (or (= 1 (- upper-2 lower-2))
-                             (= increment
-                                (- (indexer lower-0 lower-1 (+ lower-2 1) lower-3)
-                                   (indexer lower-0 lower-1    lower-2    lower-3))))
-                         (let ((increment (* increment (- upper-2 lower-2))))
-                           (and (or (= 1 (- upper-1 lower-1))
-                                    (= increment
-                                       (- (indexer lower-0 (+ lower-1 1) lower-2 lower-3)
-                                          (indexer lower-0    lower-1    lower-2 lower-3))))
-                                (let ((increment (* increment (- upper-1 lower-1))))
-                                  (or (= 1 (- upper-0 lower-0))
+                                  (- (indexer lower-0 (+ lower-1 1) lower-2)
+                                     (indexer lower-0    lower-1    lower-2))))
+                           (let ((increment (* increment (- upper-1 lower-1))))
+                             (or (= 1 (- upper-0 lower-0))
+                                 (= increment
+                                    (- (indexer (+ lower-0 1) lower-1 lower-2)
+                                       (indexer    lower-0    lower-1 lower-2)))))))))))
+      ((4) (let ((lower-0 (%%interval-lower-bound domain 0))
+                 (lower-1 (%%interval-lower-bound domain 1))
+                 (lower-2 (%%interval-lower-bound domain 2))
+                 (lower-3 (%%interval-lower-bound domain 3))
+                 (upper-0 (%%interval-upper-bound domain 0))
+                 (upper-1 (%%interval-upper-bound domain 1))
+                 (upper-2 (%%interval-upper-bound domain 2))
+                 (upper-3 (%%interval-upper-bound domain 3)))
+             (let ((increment 1))
+               (and (or (= 1 (- upper-3 lower-3))
+                        (= increment
+                           (- (indexer lower-0 lower-1 lower-2 (+ lower-3 1))
+                              (indexer lower-0 lower-1 lower-2    lower-3))))
+                    (let ((increment (* increment (- upper-3 lower-3))))
+                      (and (or (= 1 (- upper-2 lower-2))
+                               (= increment
+                                  (- (indexer lower-0 lower-1 (+ lower-2 1) lower-3)
+                                     (indexer lower-0 lower-1    lower-2    lower-3))))
+                           (let ((increment (* increment (- upper-2 lower-2))))
+                             (and (or (= 1 (- upper-1 lower-1))
                                       (= increment
-                                         (- (indexer (+ lower-0 1) lower-1 lower-2 lower-3)
-                                            (indexer    lower-0    lower-1 lower-2 lower-3)))))))))))))
-    (else (let ((global-lowers
-                 ;; will use as an argument list
-                 (%%interval-lower-bounds->list domain))
-                (global-lowers+1
-                 ;; will modify and use as an argument list
-                 (%%interval-lower-bounds->list domain)))
-            (and
-             (let loop ((lowers global-lowers+1)
-                        (uppers (%%interval-upper-bounds->list domain)))
-               ;; returns either #f or the increment
-               ;; that the difference of indexers must equal.
-               (if (null? lowers)
-                   1 ;; increment
-                   (let ((increment (loop (cdr lowers) (cdr uppers))))
-                     (and increment
-                          (or (and (= 1 (- (car uppers) (car lowers)))
-                                   ;; increment doesn't change
-                                   increment)
-                              (begin
-                                ;; increment the correct index by 1
-                                (set-car! lowers (+ (car lowers) 1))
-                                (and (= (- (apply indexer global-lowers+1)
-                                           (apply indexer global-lowers))
-                                        increment)
-                                     (begin
-                                       ;; set it back
-                                       (set-car! lowers (- (car lowers) 1))
-                                       ;; multiply the increment by the difference in
-                                       ;; the current upper and lower bounds and
-                                       ;; return it.
-                                       (* increment (- (car uppers) (car lowers)))))))))))
-             ;; return a proper boolean instead of the volume of the domain
-             #t))))))
+                                         (- (indexer lower-0 (+ lower-1 1) lower-2 lower-3)
+                                            (indexer lower-0    lower-1    lower-2 lower-3))))
+                                  (let ((increment (* increment (- upper-1 lower-1))))
+                                    (or (= 1 (- upper-0 lower-0))
+                                        (= increment
+                                           (- (indexer (+ lower-0 1) lower-1 lower-2 lower-3)
+                                              (indexer    lower-0    lower-1 lower-2 lower-3)))))))))))))
+      (else (let ((global-lowers
+                   ;; will use as an argument list
+                   (%%interval-lower-bounds->list domain))
+                  (global-lowers+1
+                   ;; will modify and use as an argument list
+                   (%%interval-lower-bounds->list domain)))
+              (and
+               (let loop ((lowers global-lowers+1)
+                          (uppers (%%interval-upper-bounds->list domain)))
+                 ;; returns either #f or the increment
+                 ;; that the difference of indexers must equal.
+                 (if (null? lowers)
+                     1 ;; increment
+                     (let ((increment (loop (cdr lowers) (cdr uppers))))
+                       (and increment
+                            (or (and (= 1 (- (car uppers) (car lowers)))
+                                     ;; increment doesn't change
+                                     increment)
+                                (begin
+                                  ;; increment the correct index by 1
+                                  (set-car! lowers (+ (car lowers) 1))
+                                  (and (= (- (apply indexer global-lowers+1)
+                                             (apply indexer global-lowers))
+                                          increment)
+                                       (begin
+                                         ;; set it back
+                                         (set-car! lowers (- (car lowers) 1))
+                                         ;; multiply the increment by the difference in
+                                         ;; the current upper and lower bounds and
+                                         ;; return it.
+                                         (* increment (- (car uppers) (car lowers)))))))))))
+               ;; return a proper boolean instead of the volume of the domain
+               #t))))))
 
 (define (array-elements-in-order? array)
   (cond ((not (specialized-array? array))
@@ -1489,10 +1458,10 @@
 
 (define (%%finish-specialized-array domain storage-class body indexer mutable? safe?)
   (let ((storage-class-getter (storage-class-getter storage-class))
-	(storage-class-setter (storage-class-setter storage-class))
-	(checker (storage-class-checker storage-class))
-	(indexer indexer)
-	(body body))
+        (storage-class-setter (storage-class-setter storage-class))
+        (checker (storage-class-checker storage-class))
+        (indexer indexer)
+        (body body))
 
     ;;; we write the following three macros to specialize the setters and getters in the
     ;;; non-safe case to reduce one more function call.
@@ -1500,27 +1469,27 @@
     (define-macro (expand-storage-class original-suffix replacement-suffix expr)
 
       (define (symbol-append . args)
-	(string->symbol (apply string-append (map (lambda (x) (if (symbol? x) (symbol->string x) x)) args))))
+        (string->symbol (apply string-append (map (lambda (x) (if (symbol? x) (symbol->string x) x)) args))))
 
       (define (replace old-symbol new-symbol expr)
-	(let loop ((expr expr))
-	  (cond ((pair? expr)           ;; we don't use map because of dotted argument list in general setter
-		 (cons (loop (car expr))
-		       (loop (cdr expr))))
-		((eq? expr old-symbol)
-		 new-symbol)
-		(else
-		 expr))))
+        (let loop ((expr expr))
+          (cond ((pair? expr)           ;; we don't use map because of dotted argument list in general setter
+                 (cons (loop (car expr))
+                       (loop (cdr expr))))
+                ((eq? expr old-symbol)
+                 new-symbol)
+                (else
+                 expr))))
 
       `(cond ,@(map (lambda (name prefix)
-		      `((eq? storage-class ,(symbol-append name '-storage-class))
-			,(replace (symbol-append 'storage-class original-suffix)
-				  (symbol-append prefix 'vector replacement-suffix)
-				  expr)))
-		    '(generic s8 u8 s16 u16 s32 u32 s64 u64 f32 f64)
-		    '(""      s8 u8 s16 u16 s32 u32 s64 u64 f32 f64))
-	     (else
-	      ,expr)))
+                      `((eq? storage-class ,(symbol-append name '-storage-class))
+                        ,(replace (symbol-append 'storage-class original-suffix)
+                                  (symbol-append prefix 'vector replacement-suffix)
+                                  expr)))
+                    '(generic s8 u8 s16 u16 s32 u32 s64 u64 f32 f64)
+                    '(""      s8 u8 s16 u16 s32 u32 s64 u64 f32 f64))
+             (else
+              ,expr)))
 
     (define-macro (expand-getters expr)
       `(expand-storage-class -getter -ref ,expr))
@@ -1580,7 +1549,7 @@
                  ((3)  (expand-getters (lambda (i j k)     (storage-class-getter body (indexer i j k)))))
                  ((4)  (expand-getters (lambda (i j k l)   (storage-class-getter body (indexer i j k l)))))
                  (else (expand-getters (lambda multi-index (storage-class-getter body (apply indexer multi-index))))))))
-	  (setter
+          (setter
            (and mutable?
                 (if safe?
                     (case (%%interval-dimension domain)
@@ -1727,13 +1696,13 @@
                                 (safe? (specialized-array-default-safe?)))
   ;; Returns a mutable specialized-array
   (cond ((not (interval? interval))
-	 (error "make-specialized-array: The first argument is not an interval: " interval))
-	((not (storage-class? storage-class))
-	 (error "make-specialized-array: The second argument is not a storage-class: " interval storage-class))
-	((not (boolean? safe?))
-	 (error "make-specialized-array: The third argument is not a boolean: " interval storage-class safe?))
-	(else
-	 (%%make-specialized-array interval
+         (error "make-specialized-array: The first argument is not an interval: " interval))
+        ((not (storage-class? storage-class))
+         (error "make-specialized-array: The second argument is not a storage-class: " interval storage-class))
+        ((not (boolean? safe?))
+         (error "make-specialized-array: The third argument is not a boolean: " interval storage-class safe?))
+        (else
+         (%%make-specialized-array interval
                                    storage-class
                                    ;; must be mutable
                                    safe?))))
@@ -1751,19 +1720,19 @@
                                   (mutable? (specialized-array-default-mutable?))
                                   (safe? (specialized-array-default-safe?)))
   (cond ((not (array? array))
-	 (error "array->specialized-array: The first argument is not an array: " array))
-	((not (storage-class? result-storage-class))
-	 (error "array->specialized-array: The second argument is not a storage-class: " result-storage-class))
-	((not (boolean? safe?))
-	 (error "array->specialized-array: The fourth argument is not a boolean: " safe?))
+         (error "array->specialized-array: The first argument is not an array: " array))
+        ((not (storage-class? result-storage-class))
+         (error "array->specialized-array: The second argument is not a storage-class: " result-storage-class))
+        ((not (boolean? safe?))
+         (error "array->specialized-array: The fourth argument is not a boolean: " safe?))
         ((not (boolean? mutable?))
-	 (error "array->specialized-array: The third argument is not a boolean: " mutable?))
-	(else
-	 (let* ((domain (%%array-domain array))
-		(result (%%make-specialized-array domain
+         (error "array->specialized-array: The third argument is not a boolean: " mutable?))
+        (else
+         (let* ((domain (%%array-domain array))
+                (result (%%make-specialized-array domain
                                                   result-storage-class
                                                   safe?))
-		(getter (%%array-getter array)))
+                (getter (%%array-getter array)))
            (if (eq? result-storage-class generic-storage-class)   ;; checker always returns #t
                (let ((body      (%%array-body result)))
                  ;; The result's indexer steps from 0 to (vector-length body) so we
@@ -1846,7 +1815,7 @@
                   domain)))
            (if (not mutable?)            ;; set the setter to #f if the final array is not mutable
                (%%array-setter-set! result #f))
-	   result))))
+           result))))
 
 ;;;
 ;;; In the next function, old-indexer is an affine 1-1 mapping from an interval to [0,N), for some N.
@@ -1857,131 +1826,131 @@
 (define (%%compose-indexers old-indexer new-domain new-domain->old-domain)
   (case (%%interval-dimension new-domain)
     ((1) (let* ((lower-0 (%%interval-lower-bound new-domain 0))
-		(upper-0 (%%interval-upper-bound new-domain 0))
-		(base (call-with-values
-			  (lambda () (new-domain->old-domain lower-0))
-			old-indexer))
-		(increment-0 (if (< (+ lower-0 1) upper-0)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain (+ lower-0 1)))
-				      old-indexer)
-				    base)
-				 0)))
-	   (%%indexer-1 base lower-0 increment-0)))
+                (upper-0 (%%interval-upper-bound new-domain 0))
+                (base (call-with-values
+                          (lambda () (new-domain->old-domain lower-0))
+                        old-indexer))
+                (increment-0 (if (< (+ lower-0 1) upper-0)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain (+ lower-0 1)))
+                                      old-indexer)
+                                    base)
+                                 0)))
+           (%%indexer-1 base lower-0 increment-0)))
 
     ((2) (let* ((lower-0 (%%interval-lower-bound new-domain 0))
-		(lower-1 (%%interval-lower-bound new-domain 1))
-		(upper-0 (%%interval-upper-bound new-domain 0))
-		(upper-1 (%%interval-upper-bound new-domain 1))
-		(base (call-with-values
-			  (lambda () (new-domain->old-domain lower-0 lower-1))
-			old-indexer))
-		(increment-0 (if (< (+ lower-0 1) upper-0)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain (+ lower-0 1) lower-1))
-				      old-indexer)
-				    base)
-				 0))
-		(increment-1 (if (< (+ lower-1 1) upper-1)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain lower-0 (+ lower-1 1)))
-				      old-indexer)
-				    base)
-				 0)))
-	   (%%indexer-2 base lower-0 lower-1 increment-0 increment-1)))
+                (lower-1 (%%interval-lower-bound new-domain 1))
+                (upper-0 (%%interval-upper-bound new-domain 0))
+                (upper-1 (%%interval-upper-bound new-domain 1))
+                (base (call-with-values
+                          (lambda () (new-domain->old-domain lower-0 lower-1))
+                        old-indexer))
+                (increment-0 (if (< (+ lower-0 1) upper-0)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain (+ lower-0 1) lower-1))
+                                      old-indexer)
+                                    base)
+                                 0))
+                (increment-1 (if (< (+ lower-1 1) upper-1)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain lower-0 (+ lower-1 1)))
+                                      old-indexer)
+                                    base)
+                                 0)))
+           (%%indexer-2 base lower-0 lower-1 increment-0 increment-1)))
     ((3) (let* ((lower-0 (%%interval-lower-bound new-domain 0))
-		(lower-1 (%%interval-lower-bound new-domain 1))
-		(lower-2 (%%interval-lower-bound new-domain 2))
-		(upper-0 (%%interval-upper-bound new-domain 0))
-		(upper-1 (%%interval-upper-bound new-domain 1))
-		(upper-2 (%%interval-upper-bound new-domain 2))
-		(base (call-with-values
-			  (lambda () (new-domain->old-domain lower-0 lower-1 lower-2))
-			old-indexer))
-		(increment-0 (if (< (+ lower-0 1) upper-0)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain (+ lower-0 1) lower-1 lower-2))
-				      old-indexer)
-				    base)
-				 0))
-		(increment-1 (if (< (+ lower-1 1) upper-1)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain lower-0 (+ lower-1 1) lower-2))
-				      old-indexer)
-				    base)
-				 0))
-		(increment-2 (if (< (+ lower-2 1) upper-2)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain lower-0 lower-1 (+ lower-2 1)))
-				      old-indexer)
-				    base)
-				 0)))
-	   (%%indexer-3 base lower-0 lower-1 lower-2 increment-0 increment-1 increment-2)))
+                (lower-1 (%%interval-lower-bound new-domain 1))
+                (lower-2 (%%interval-lower-bound new-domain 2))
+                (upper-0 (%%interval-upper-bound new-domain 0))
+                (upper-1 (%%interval-upper-bound new-domain 1))
+                (upper-2 (%%interval-upper-bound new-domain 2))
+                (base (call-with-values
+                          (lambda () (new-domain->old-domain lower-0 lower-1 lower-2))
+                        old-indexer))
+                (increment-0 (if (< (+ lower-0 1) upper-0)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain (+ lower-0 1) lower-1 lower-2))
+                                      old-indexer)
+                                    base)
+                                 0))
+                (increment-1 (if (< (+ lower-1 1) upper-1)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain lower-0 (+ lower-1 1) lower-2))
+                                      old-indexer)
+                                    base)
+                                 0))
+                (increment-2 (if (< (+ lower-2 1) upper-2)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain lower-0 lower-1 (+ lower-2 1)))
+                                      old-indexer)
+                                    base)
+                                 0)))
+           (%%indexer-3 base lower-0 lower-1 lower-2 increment-0 increment-1 increment-2)))
     ((4) (let* ((lower-0 (%%interval-lower-bound new-domain 0))
-		(lower-1 (%%interval-lower-bound new-domain 1))
-		(lower-2 (%%interval-lower-bound new-domain 2))
-		(lower-3 (%%interval-lower-bound new-domain 3))
-		(upper-0 (%%interval-upper-bound new-domain 0))
-		(upper-1 (%%interval-upper-bound new-domain 1))
-		(upper-2 (%%interval-upper-bound new-domain 2))
-		(upper-3 (%%interval-upper-bound new-domain 3))
-		(base (call-with-values
-			  (lambda () (new-domain->old-domain lower-0 lower-1 lower-2 lower-3))
-			old-indexer))
-		(increment-0 (if (< (+ lower-0 1) upper-0)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain (+ lower-0 1) lower-1 lower-2 lower-3))
-				      old-indexer)
-				    base)
-				 0))
-		(increment-1 (if (< (+ lower-1 1) upper-1)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain lower-0 (+ lower-1 1) lower-2 lower-3))
-				      old-indexer)
-				    base)
-				 0))
-		(increment-2 (if (< (+ lower-2 1) upper-2)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain lower-0 lower-1 (+ lower-2 1) lower-3))
-				      old-indexer)
-				    base)
-				 0))
-		(increment-3 (if (< (+ lower-3 1) upper-3)
-				 (- (call-with-values
-					(lambda () (new-domain->old-domain lower-0 lower-1 lower-2 (+ lower-3 1)))
-				      old-indexer)
-				    base)
-				 0)))
-	   (%%indexer-4 base lower-0 lower-1 lower-2 lower-3 increment-0 increment-1 increment-2 increment-3)))
+                (lower-1 (%%interval-lower-bound new-domain 1))
+                (lower-2 (%%interval-lower-bound new-domain 2))
+                (lower-3 (%%interval-lower-bound new-domain 3))
+                (upper-0 (%%interval-upper-bound new-domain 0))
+                (upper-1 (%%interval-upper-bound new-domain 1))
+                (upper-2 (%%interval-upper-bound new-domain 2))
+                (upper-3 (%%interval-upper-bound new-domain 3))
+                (base (call-with-values
+                          (lambda () (new-domain->old-domain lower-0 lower-1 lower-2 lower-3))
+                        old-indexer))
+                (increment-0 (if (< (+ lower-0 1) upper-0)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain (+ lower-0 1) lower-1 lower-2 lower-3))
+                                      old-indexer)
+                                    base)
+                                 0))
+                (increment-1 (if (< (+ lower-1 1) upper-1)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain lower-0 (+ lower-1 1) lower-2 lower-3))
+                                      old-indexer)
+                                    base)
+                                 0))
+                (increment-2 (if (< (+ lower-2 1) upper-2)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain lower-0 lower-1 (+ lower-2 1) lower-3))
+                                      old-indexer)
+                                    base)
+                                 0))
+                (increment-3 (if (< (+ lower-3 1) upper-3)
+                                 (- (call-with-values
+                                        (lambda () (new-domain->old-domain lower-0 lower-1 lower-2 (+ lower-3 1)))
+                                      old-indexer)
+                                    base)
+                                 0)))
+           (%%indexer-4 base lower-0 lower-1 lower-2 lower-3 increment-0 increment-1 increment-2 increment-3)))
     (else
      (let* ((lower-bounds (%%interval-lower-bounds->list new-domain))
-	    (upper-bounds (%%interval-upper-bounds->list new-domain))
-	    (base (call-with-values
-		      (lambda () (apply new-domain->old-domain lower-bounds))
-		    old-indexer))
-	    (increments (let ((increments   (map (lambda (x) 0) lower-bounds))
-			      (lower-bounds (map (lambda (x) x) lower-bounds)))
-			  (let loop ((l lower-bounds)
-				     (u upper-bounds)
-				     (i increments)
-				     (base base))
-			    (if (null? l)
-				increments
-				(let ((new-base
-				       (if (< (+ (car l) 1)
-					      (car u))
-					   (begin
-					     (set-car! l (+ (car l) 1))
-					     (let ((new-base (call-with-values
-								 (lambda () (apply new-domain->old-domain lower-bounds))
-							       old-indexer)))
-					       (set-car! i (- new-base base))
-					       new-base))
-					   base)))
-				  (loop (cdr l)
-					(cdr u)
-					(cdr i)
-					new-base)))))))
+            (upper-bounds (%%interval-upper-bounds->list new-domain))
+            (base (call-with-values
+                      (lambda () (apply new-domain->old-domain lower-bounds))
+                    old-indexer))
+            (increments (let ((increments   (map (lambda (x) 0) lower-bounds))
+                              (lower-bounds (map (lambda (x) x) lower-bounds)))
+                          (let loop ((l lower-bounds)
+                                     (u upper-bounds)
+                                     (i increments)
+                                     (base base))
+                            (if (null? l)
+                                increments
+                                (let ((new-base
+                                       (if (< (+ (car l) 1)
+                                              (car u))
+                                           (begin
+                                             (set-car! l (+ (car l) 1))
+                                             (let ((new-base (call-with-values
+                                                                 (lambda () (apply new-domain->old-domain lower-bounds))
+                                                               old-indexer)))
+                                               (set-car! i (- new-base base))
+                                               new-base))
+                                           base)))
+                                  (loop (cdr l)
+                                        (cdr u)
+                                        (cdr i)
+                                        new-base)))))))
        (%%indexer-generic base lower-bounds increments)))))
 
 ;;; You want to share the backing store of array.
@@ -2004,30 +1973,30 @@
 
 
 (define (specialized-array-share array
-				 new-domain
-				 new-domain->old-domain)
+                                 new-domain
+                                 new-domain->old-domain)
   (cond ((not (specialized-array? array))
-	 (error "specialized-array-share: The first argument is not a specialized-array: "
+         (error "specialized-array-share: The first argument is not a specialized-array: "
                 array new-domain new-domain->old-domain))
-	((not (interval? new-domain))
-	 (error "specialized-array-share: The second argument is not an interval: "
+        ((not (interval? new-domain))
+         (error "specialized-array-share: The second argument is not an interval: "
                 array new-domain new-domain->old-domain))
-	((not (procedure? new-domain->old-domain))
-	 (error "specialized-array-share: The third argument is not a procedure: "
+        ((not (procedure? new-domain->old-domain))
+         (error "specialized-array-share: The third argument is not a procedure: "
                 array new-domain new-domain->old-domain))
-	(else
-	 (%%specialized-array-share array
+        (else
+         (%%specialized-array-share array
                                     new-domain
                                     new-domain->old-domain))))
 
 (define (%%immutable-array-extract array new-domain)
   (make-array new-domain
-	      (%%array-getter array)))
+              (%%array-getter array)))
 
 (define (%%mutable-array-extract array new-domain)
   (make-array new-domain
-	      (%%array-getter array)
-	      (%%array-setter array)))
+              (%%array-getter array)
+              (%%array-setter array)))
 
 (define (%%specialized-array-extract array new-domain)
   (%%specialized-array-share array
@@ -2036,24 +2005,24 @@
 
 (define (%%array-extract array new-domain)
   (cond ((specialized-array? array)
-	 (%%specialized-array-extract array new-domain))
-	((mutable-array? array)
-	 (%%mutable-array-extract array new-domain))
-	(else
-	 (%%immutable-array-extract array new-domain))))
+         (%%specialized-array-extract array new-domain))
+        ((mutable-array? array)
+         (%%mutable-array-extract array new-domain))
+        (else
+         (%%immutable-array-extract array new-domain))))
 
 (define (array-extract array new-domain)
   (cond ((not (array? array))
-	 (error "array-extract: The first argument is not an array: " array new-domain))
-	((not (interval? new-domain))
-	 (error "array-extract: The second argument is not an interval: " array new-domain))
+         (error "array-extract: The first argument is not an array: " array new-domain))
+        ((not (interval? new-domain))
+         (error "array-extract: The second argument is not an interval: " array new-domain))
         ((not (= (%%interval-dimension (%%array-domain array))
                  (%%interval-dimension new-domain)))
          (error "array-extract: The dimension of the second argument (an interval) does not equal the dimension of the domain of the first argument (an array): " array new-domain))
-	((not (%%interval-subset? new-domain (%%array-domain array)))
-	 (error "array-extract: The second argument (an interval) is not a subset of the domain of the first argument (an array): " array new-domain))
-	(else
-	 (%%array-extract array new-domain))))
+        ((not (%%interval-subset? new-domain (%%array-domain array)))
+         (error "array-extract: The second argument (an interval) is not a subset of the domain of the first argument (an array): " array new-domain))
+        (else
+         (%%array-extract array new-domain))))
 
 (define (array-tile array sides)
   (cond ((not (array? array))
@@ -2156,65 +2125,65 @@
 (define (%%getter-translate getter translation)
   (case (vector-length translation)
     ((1) (lambda (i)
-	   (getter (- i (vector-ref translation 0)))))
+           (getter (- i (vector-ref translation 0)))))
     ((2) (lambda (i j)
-	   (getter (- i (vector-ref translation 0))
-		   (- j (vector-ref translation 1)))))
+           (getter (- i (vector-ref translation 0))
+                   (- j (vector-ref translation 1)))))
     ((3) (lambda (i j k)
-	   (getter (- i (vector-ref translation 0))
-		   (- j (vector-ref translation 1))
-		   (- k (vector-ref translation 2)))))
+           (getter (- i (vector-ref translation 0))
+                   (- j (vector-ref translation 1))
+                   (- k (vector-ref translation 2)))))
     ((4) (lambda (i j k l)
-	   (getter (- i (vector-ref translation 0))
-		   (- j (vector-ref translation 1))
-		   (- k (vector-ref translation 2))
-		   (- l (vector-ref translation 3)))))
+           (getter (- i (vector-ref translation 0))
+                   (- j (vector-ref translation 1))
+                   (- k (vector-ref translation 2))
+                   (- l (vector-ref translation 3)))))
     (else
      (let ((n (vector-length translation))
-	   (translation-list (vector->list translation)))
+           (translation-list (vector->list translation)))
        (lambda indices
-	 (cond ((not (= (length indices) n))
-		(error "The number of indices does not equal the array dimension: " indices))
-	       (else
-		(apply getter (map - indices translation-list)))))))))
+         (cond ((not (= (length indices) n))
+                (error "The number of indices does not equal the array dimension: " indices))
+               (else
+                (apply getter (map - indices translation-list)))))))))
 
 (define (%%setter-translate setter translation)
   (case (vector-length translation)
     ((1) (lambda (v i)
-	   (setter v
-		   (- i (vector-ref translation 0)))))
+           (setter v
+                   (- i (vector-ref translation 0)))))
     ((2) (lambda (v i j)
-	   (setter v
-		   (- i (vector-ref translation 0))
-		   (- j (vector-ref translation 1)))))
+           (setter v
+                   (- i (vector-ref translation 0))
+                   (- j (vector-ref translation 1)))))
     ((3) (lambda (v i j k)
-	   (setter v
-		   (- i (vector-ref translation 0))
-		   (- j (vector-ref translation 1))
-		   (- k (vector-ref translation 2)))))
+           (setter v
+                   (- i (vector-ref translation 0))
+                   (- j (vector-ref translation 1))
+                   (- k (vector-ref translation 2)))))
     ((4) (lambda (v i j k l)
-	   (setter v
-		   (- i (vector-ref translation 0))
-		   (- j (vector-ref translation 1))
-		   (- k (vector-ref translation 2))
-		   (- l (vector-ref translation 3)))))
+           (setter v
+                   (- i (vector-ref translation 0))
+                   (- j (vector-ref translation 1))
+                   (- k (vector-ref translation 2))
+                   (- l (vector-ref translation 3)))))
     (else
      (let ((n (vector-length translation))
-	   (translation-list (vector->list translation)))
+           (translation-list (vector->list translation)))
        (lambda (v . indices)
-	 (cond ((not (= (length indices) n))
-		(error "The number of indices does not equal the array dimension: " v indices))
-	       (else
-		(apply setter v (map - indices translation-list)))))))))
+         (cond ((not (= (length indices) n))
+                (error "The number of indices does not equal the array dimension: " v indices))
+               (else
+                (apply setter v (map - indices translation-list)))))))))
 
 (define (%%immutable-array-translate array translation)
   (make-array (%%interval-translate (%%array-domain array) translation)
-	      (%%getter-translate (%%array-getter array) translation)))
+              (%%getter-translate (%%array-getter array) translation)))
 
 (define (%%mutable-array-translate array translation)
   (make-array (%%interval-translate (%%array-domain array) translation)
-	      (%%getter-translate (%%array-getter array) translation)
-	      (%%setter-translate (%%array-setter array) translation)))
+              (%%getter-translate (%%array-getter array) translation)
+              (%%setter-translate (%%array-setter array) translation)))
 
 (define (%%specialized-array-translate array translation)
   (%%specialized-array-share array
@@ -2223,39 +2192,39 @@
 
 (define (array-translate array translation)
   (cond ((not (array? array))
-	 (error "array-translate: The first argument is not an array: " array translation))
-	((not (translation? translation))
-	 (error "array-translate: The second argument is not a vector of exact integers: " array translation))
-	((not (fx= (%%array-dimension array)
-		   (vector-length translation)))
-	 (error "array-translate: The dimension of the first argument (an array) does not equal the dimension of the second argument (a vector): " array translation))
-	((specialized-array? array)
-	 (%%specialized-array-translate array translation))
-	((mutable-array? array)
-	 (%%mutable-array-translate array translation))
-	(else
-	 (%%immutable-array-translate array translation))))
+         (error "array-translate: The first argument is not an array: " array translation))
+        ((not (translation? translation))
+         (error "array-translate: The second argument is not a vector of exact integers: " array translation))
+        ((not (fx= (%%array-dimension array)
+                   (vector-length translation)))
+         (error "array-translate: The dimension of the first argument (an array) does not equal the dimension of the second argument (a vector): " array translation))
+        ((specialized-array? array)
+         (%%specialized-array-translate array translation))
+        ((mutable-array? array)
+         (%%mutable-array-translate array translation))
+        (else
+         (%%immutable-array-translate array translation))))
 
 (define-macro (setup-permuted-getters-and-setters)
 
   (define (list-remove l i)
     ;; new list that removes (list-ref l i) from l
     (if (zero? i)
-	(cdr l)
-	(cons (car l)
-	      (list-remove (cdr l) (- i 1)))))
+        (cdr l)
+        (cons (car l)
+              (list-remove (cdr l) (- i 1)))))
 
   (define (permutations l)
     ;; generates list of all permutations of l
     (if (null? (cdr l))
-	(list l)
-	(apply append (map (lambda (i)
-			     (let ((x    (list-ref l i))
-				   (rest (list-remove l i)))
-			       (map (lambda (tail)
-				      (cons x tail))
-				    (permutations rest))))
-			   (iota (length l))))))
+        (list l)
+        (apply append (map (lambda (i)
+                             (let ((x    (list-ref l i))
+                                   (rest (list-remove l i)))
+                               (map (lambda (tail)
+                                      (cons x tail))
+                                    (permutations rest))))
+                           (iota (length l))))))
 
   (define (concat . args)
     (string->symbol (apply string-append (map (lambda (s) (if (string? s) s (symbol->string s ))) args))))
@@ -2263,27 +2232,27 @@
   (define (permuter name transform-arguments)
     `(define (,(concat name '-permute) ,name permutation)
        (case (vector-length permutation)
-	 ,@(map (lambda (i)
-		  `((,i) (cond ,@(let ((args (take '(i j k l) i)))
-				   (map (lambda (perm permuted-args)
-					  `((equal? permutation ',(list->vector perm))
-					    (lambda ,(transform-arguments permuted-args)
-					      ,`(,name ,@(transform-arguments args)))))
-					(permutations (take '(0 1 2 3) i))
-					(permutations args))))))
-		'(1 2 3 4))
-	 (else
-	  (let ((n (vector-length permutation))
-		(permutation-inverse (%%permutation-invert permutation)))
-	    (lambda ,(transform-arguments 'indices)
-	      (if (not (= (length indices) n))
-		  (error "number of indices does not equal permutation dimension: " indices permutation)
-		  (apply ,name ,@(transform-arguments '((%%vector-permute->list (list->vector indices) permutation-inverse)))))))))))
+         ,@(map (lambda (i)
+                  `((,i) (cond ,@(let ((args (take '(i j k l) i)))
+                                   (map (lambda (perm permuted-args)
+                                          `((equal? permutation ',(list->vector perm))
+                                            (lambda ,(transform-arguments permuted-args)
+                                              ,`(,name ,@(transform-arguments args)))))
+                                        (permutations (take '(0 1 2 3) i))
+                                        (permutations args))))))
+                '(1 2 3 4))
+         (else
+          (let ((n (vector-length permutation))
+                (permutation-inverse (%%permutation-invert permutation)))
+            (lambda ,(transform-arguments 'indices)
+              (if (not (= (length indices) n))
+                  (error "number of indices does not equal permutation dimension: " indices permutation)
+                  (apply ,name ,@(transform-arguments '((%%vector-permute->list (list->vector indices) permutation-inverse)))))))))))
 
   (let ((result
-	 `(begin
-	    ,(permuter '%%getter values)
-	    ,(permuter '%%setter (lambda (args) (cons 'v args))))))
+         `(begin
+            ,(permuter '%%getter values)
+            ,(permuter '%%setter (lambda (args) (cons 'v args))))))
     result))
 
 (setup-permuted-getters-and-setters)
@@ -2303,14 +2272,14 @@
 
 (define (array-permute array permutation)
   (cond ((not (array? array))
-	 (error "array-permute: The first argument is not an array: " array permutation))
-	((not (permutation? permutation))
-	 (error "array-permute: The second argument is not a permutation: " array permutation))
-	((not (fx= (%%array-dimension array)
-		   (vector-length permutation)))
-	 (error "array-permute: The dimension of the first argument (an array) does not equal the dimension of the second argument (a permutation): " array permutation))
-	(else
-	 (%%array-permute array permutation))))
+         (error "array-permute: The first argument is not an array: " array permutation))
+        ((not (permutation? permutation))
+         (error "array-permute: The second argument is not a permutation: " array permutation))
+        ((not (fx= (%%array-dimension array)
+                   (vector-length permutation)))
+         (error "array-permute: The dimension of the first argument (an array) does not equal the dimension of the second argument (a permutation): " array permutation))
+        (else
+         (%%array-permute array permutation))))
 
 (define (%%rotation->permutation k size)
   
@@ -2358,85 +2327,85 @@
   (define (make-symbol . args)
     (string->symbol
      (apply string-append
-	    (map (lambda (x)
-		   (cond ((string? x) x)
-			 ((symbol? x) (symbol->string x))
-			 ((number? x) (number->string x))))
-		 args))))
+            (map (lambda (x)
+                   (cond ((string? x) x)
+                         ((symbol? x) (symbol->string x))
+                         ((number? x) (number->string x))))
+                 args))))
 
   (define (truth-table n)   ;; generate all combinations of n #t and #f
     (if (zero? n)
-	'(())
-	(let ((subtable (truth-table (- n 1))))
-	  (apply append (map (lambda (value)
-			       (map (lambda (t)
-				      (cons value t))
-				    subtable))
-			     '(#t #f))))))
+        '(())
+        (let ((subtable (truth-table (- n 1))))
+          (apply append (map (lambda (value)
+                               (map (lambda (t)
+                                      (cons value t))
+                                    subtable))
+                             '(#t #f))))))
 
   (define (generate-code-for-fixed-n name transformer n)
     (let ((zero-to-n-1
-	   (iota n))
-	  (table
-	   (truth-table n)))
+           (iota n))
+          (table
+           (truth-table n)))
       `((,n) (let (,@(map (lambda (k)
-			    `(,(make-symbol 'adjust_ k) (+ (%%interval-upper-bound interval ,k)
-							   (%%interval-lower-bound interval ,k)
-							   -1)))
-			  zero-to-n-1))
-	       (cond ,@(map (lambda (table-entry)
-			      `((equal? flip? ',(list->vector table-entry))
-				(lambda ,(transformer (map (lambda (k)
-							     (make-symbol 'i_ k))
-							   zero-to-n-1))
-				  (,name ,@(transformer (map (lambda (flip? k)
-							       (if flip?
-								   `(- ,(make-symbol 'adjust_ k)
-								       ,(make-symbol 'i_ k))
-								   `,(make-symbol 'i_ k)))
-							     table-entry zero-to-n-1))))))
-			    table))))))
+                            `(,(make-symbol 'adjust_ k) (+ (%%interval-upper-bound interval ,k)
+                                                           (%%interval-lower-bound interval ,k)
+                                                           -1)))
+                          zero-to-n-1))
+               (cond ,@(map (lambda (table-entry)
+                              `((equal? flip? ',(list->vector table-entry))
+                                (lambda ,(transformer (map (lambda (k)
+                                                             (make-symbol 'i_ k))
+                                                           zero-to-n-1))
+                                  (,name ,@(transformer (map (lambda (flip? k)
+                                                               (if flip?
+                                                                   `(- ,(make-symbol 'adjust_ k)
+                                                                       ,(make-symbol 'i_ k))
+                                                                   `,(make-symbol 'i_ k)))
+                                                             table-entry zero-to-n-1))))))
+                            table))))))
 
   (define (reverser name transform-arguments)
     `(define (,(make-symbol name '-reverse) ,name flip? interval)
        (case (vector-length flip?)
-	 ,@(map (lambda (n)
-		  (generate-code-for-fixed-n name transform-arguments n))
-		'(1 2 3 4))
-	 (else
-	  (let ((n
-		 (vector-length flip?))
-		(flip?
-		 (vector->list flip?))
-		(adjust
-		 (map (lambda (u_k l_k)
-			(+ u_k l_k -1))
-		      (vector->list (%%interval-upper-bounds interval))
-		      (vector->list (%%interval-lower-bounds interval)))))
-	    (lambda ,(transform-arguments 'indices)
-	      (if (not (= (length indices) n))
-		  (error "number of indices does not equal array dimension: " indices)
-		  (apply ,name ,@(transform-arguments '((map (lambda (i adjust flip?)
-							       (if flip?
-								   (- adjust i)
-								   i))
-							     indices adjust flip?)))))))))))
+         ,@(map (lambda (n)
+                  (generate-code-for-fixed-n name transform-arguments n))
+                '(1 2 3 4))
+         (else
+          (let ((n
+                 (vector-length flip?))
+                (flip?
+                 (vector->list flip?))
+                (adjust
+                 (map (lambda (u_k l_k)
+                        (+ u_k l_k -1))
+                      (vector->list (%%interval-upper-bounds interval))
+                      (vector->list (%%interval-lower-bounds interval)))))
+            (lambda ,(transform-arguments 'indices)
+              (if (not (= (length indices) n))
+                  (error "number of indices does not equal array dimension: " indices)
+                  (apply ,name ,@(transform-arguments '((map (lambda (i adjust flip?)
+                                                               (if flip?
+                                                                   (- adjust i)
+                                                                   i))
+                                                             indices adjust flip?)))))))))))
   (let ((result
-	 `(begin
-	    ,(reverser '%%getter values)
-	    ,(reverser '%%setter (lambda (args) (cons 'v args))))))
+         `(begin
+            ,(reverser '%%getter values)
+            ,(reverser '%%setter (lambda (args) (cons 'v args))))))
     result))
 
 (setup-reversed-getters-and-setters)
 
 (define (%%immutable-array-reverse array flip?)
   (make-array (%%array-domain array)
-	      (%%getter-reverse (%%array-getter array) flip? (%%array-domain array))))
+              (%%getter-reverse (%%array-getter array) flip? (%%array-domain array))))
 
 (define (%%mutable-array-reverse array flip?)
   (make-array (%%array-domain array)
-	      (%%getter-reverse (%%array-getter array) flip? (%%array-domain array))
-	      (%%setter-reverse (%%array-setter array) flip? (%%array-domain array))))
+              (%%getter-reverse (%%array-getter array) flip? (%%array-domain array))
+              (%%setter-reverse (%%array-setter array) flip? (%%array-domain array))))
 
 (define (%%specialized-array-reverse array flip?)
   (%%specialized-array-share array
@@ -2469,11 +2438,11 @@
   (define (make-symbol . args)
     (string->symbol
      (apply string-append
-	    (map (lambda (x)
-		   (cond ((string? x) x)
-			 ((symbol? x) (symbol->string x))
-			 ((number? x) (number->string x))))
-		 args))))
+            (map (lambda (x)
+                   (cond ((string? x) x)
+                         ((symbol? x) (symbol->string x))
+                         ((number? x) (number->string x))))
+                 args))))
 
   (define (first-half l)
     (take l (quotient (length l) 2)))
@@ -2564,8 +2533,8 @@
 
 (define (%%mutable-array-sample array scales)
   (make-array (%%interval-scale (%%array-domain array) scales)
-	      (%%getter-sample (%%array-getter array) scales (%%array-domain array))
-	      (%%setter-sample (%%array-setter array) scales (%%array-domain array))))
+              (%%getter-sample (%%array-getter array) scales (%%array-domain array))
+              (%%setter-sample (%%array-setter array) scales (%%array-domain array))))
 
 (define (%%specialized-array-sample array scales)
   (%%specialized-array-share array
@@ -2666,67 +2635,67 @@
       (lambda () (interval-projections (%%array-domain array) right-dimension))
     (lambda (left-interval right-interval)
       (let ((getter (%%array-getter array)))
-	(make-array left-interval
-		    (case (%%interval-dimension left-interval)
-		      ((1)  (case (%%interval-dimension right-interval)
-			      ((1)  (lambda (i)      (make-array right-interval (lambda (j)         (getter i j)))))
-			      ((2)  (lambda (i)      (make-array right-interval (lambda (j k)       (getter i j k)))))
-			      ((3)  (lambda (i)      (make-array right-interval (lambda (j k l)     (getter i j k l)))))
-			      (else (lambda (i)      (make-array right-interval (lambda multi-index (apply getter i multi-index)))))))
-		      ((2)  (case (%%interval-dimension right-interval)
-			      ((1)  (lambda (i j)    (make-array right-interval (lambda   (k)       (getter i j k)))))
-			      ((2)  (lambda (i j)    (make-array right-interval (lambda   (k l)     (getter i j k l)))))
-			      (else (lambda (i j)    (make-array right-interval (lambda multi-index (apply getter i j multi-index)))))))
-		      ((3)  (case (%%interval-dimension right-interval)
-			      ((1)  (lambda (i j k)  (make-array right-interval (lambda     (l)     (getter i j k l)))))
-			      (else (lambda (i j k)  (make-array right-interval (lambda multi-index (apply getter i j k multi-index)))))))
-		      (else (lambda left-multi-index
-			      (make-array right-interval
-					  (lambda right-multi-index
-					    (apply getter (append left-multi-index right-multi-index))))))))))))
+        (make-array left-interval
+                    (case (%%interval-dimension left-interval)
+                      ((1)  (case (%%interval-dimension right-interval)
+                              ((1)  (lambda (i)      (make-array right-interval (lambda (j)         (getter i j)))))
+                              ((2)  (lambda (i)      (make-array right-interval (lambda (j k)       (getter i j k)))))
+                              ((3)  (lambda (i)      (make-array right-interval (lambda (j k l)     (getter i j k l)))))
+                              (else (lambda (i)      (make-array right-interval (lambda multi-index (apply getter i multi-index)))))))
+                      ((2)  (case (%%interval-dimension right-interval)
+                              ((1)  (lambda (i j)    (make-array right-interval (lambda   (k)       (getter i j k)))))
+                              ((2)  (lambda (i j)    (make-array right-interval (lambda   (k l)     (getter i j k l)))))
+                              (else (lambda (i j)    (make-array right-interval (lambda multi-index (apply getter i j multi-index)))))))
+                      ((3)  (case (%%interval-dimension right-interval)
+                              ((1)  (lambda (i j k)  (make-array right-interval (lambda     (l)     (getter i j k l)))))
+                              (else (lambda (i j k)  (make-array right-interval (lambda multi-index (apply getter i j k multi-index)))))))
+                      (else (lambda left-multi-index
+                              (make-array right-interval
+                                          (lambda right-multi-index
+                                            (apply getter (append left-multi-index right-multi-index))))))))))))
 
 (define (%%mutable-array-curry array right-dimension)
   (call-with-values
       (lambda () (interval-projections (%%array-domain array) right-dimension))
     (lambda (left-interval right-interval)
       (let ((getter (%%array-getter array))
-	    (setter (%%array-setter   array)))
-	(make-array left-interval
-		    (case (%%interval-dimension left-interval)
-		      ((1)  (case (%%interval-dimension right-interval)
-			      ((1)  (lambda (i)     (make-array right-interval
-								(lambda (  j)     (getter   i j))
-								(lambda (v j)     (setter v i j)))))
-			      ((2)  (lambda (i)     (make-array right-interval
-								(lambda (  j k)   (getter   i j k))
-								(lambda (v j k)   (setter v i j k)))))
-			      ((3)  (lambda (i)     (make-array right-interval
-								(lambda (  j k l) (getter   i j k l))
-								(lambda (v j k l) (setter v i j k l)))))
-			      (else (lambda (i)     (make-array right-interval
-								(lambda      multi-index  (apply getter   i     multi-index))
-								(lambda (v . multi-index) (apply setter v i     multi-index)))))))
-		      ((2)  (case (%%interval-dimension right-interval)
-			      ((1)  (lambda (i j)   (make-array right-interval
-								(lambda (    k)   (getter   i j k))
-								(lambda (v   k)   (setter v i j k)))))
-			      ((2)  (lambda (i j)   (make-array right-interval
-								(lambda (    k l) (getter   i j k l))
-								(lambda (v   k l) (setter v i j k l)))))
-			      (else (lambda (i j)   (make-array right-interval
-								(lambda      multi-index  (apply getter   i j   multi-index))
-								(lambda (v . multi-index) (apply setter v i j   multi-index)))))))
-		      ((3)  (case (%%interval-dimension right-interval)
-			      ((1)  (lambda (i j k) (make-array right-interval
-								(lambda (      l) (getter   i j k l))
-								(lambda (v     l) (setter v i j k l)))))
-			      (else (lambda (i j k) (make-array right-interval
-								(lambda      multi-index  (apply getter   i j k multi-index))
-								(lambda (v . multi-index) (apply setter v i j k multi-index)))))))
-		      (else (lambda left-multi-index
-			      (make-array right-interval
-					  (lambda      right-multi-index  (apply getter   (append left-multi-index right-multi-index)))
-					  (lambda (v . right-multi-index) (apply setter v (append left-multi-index right-multi-index))))))))))))
+            (setter (%%array-setter   array)))
+        (make-array left-interval
+                    (case (%%interval-dimension left-interval)
+                      ((1)  (case (%%interval-dimension right-interval)
+                              ((1)  (lambda (i)     (make-array right-interval
+                                                                (lambda (  j)     (getter   i j))
+                                                                (lambda (v j)     (setter v i j)))))
+                              ((2)  (lambda (i)     (make-array right-interval
+                                                                (lambda (  j k)   (getter   i j k))
+                                                                (lambda (v j k)   (setter v i j k)))))
+                              ((3)  (lambda (i)     (make-array right-interval
+                                                                (lambda (  j k l) (getter   i j k l))
+                                                                (lambda (v j k l) (setter v i j k l)))))
+                              (else (lambda (i)     (make-array right-interval
+                                                                (lambda      multi-index  (apply getter   i     multi-index))
+                                                                (lambda (v . multi-index) (apply setter v i     multi-index)))))))
+                      ((2)  (case (%%interval-dimension right-interval)
+                              ((1)  (lambda (i j)   (make-array right-interval
+                                                                (lambda (    k)   (getter   i j k))
+                                                                (lambda (v   k)   (setter v i j k)))))
+                              ((2)  (lambda (i j)   (make-array right-interval
+                                                                (lambda (    k l) (getter   i j k l))
+                                                                (lambda (v   k l) (setter v i j k l)))))
+                              (else (lambda (i j)   (make-array right-interval
+                                                                (lambda      multi-index  (apply getter   i j   multi-index))
+                                                                (lambda (v . multi-index) (apply setter v i j   multi-index)))))))
+                      ((3)  (case (%%interval-dimension right-interval)
+                              ((1)  (lambda (i j k) (make-array right-interval
+                                                                (lambda (      l) (getter   i j k l))
+                                                                (lambda (v     l) (setter v i j k l)))))
+                              (else (lambda (i j k) (make-array right-interval
+                                                                (lambda      multi-index  (apply getter   i j k multi-index))
+                                                                (lambda (v . multi-index) (apply setter v i j k multi-index)))))))
+                      (else (lambda left-multi-index
+                              (make-array right-interval
+                                          (lambda      right-multi-index  (apply getter   (append left-multi-index right-multi-index)))
+                                          (lambda (v . right-multi-index) (apply setter v (append left-multi-index right-multi-index))))))))))))
 
 (define (%%specialized-array-curry array right-dimension)
   (call-with-values
@@ -2752,17 +2721,17 @@
 
 (define (array-curry array right-dimension)
   (cond ((not (array? array))
-	 (error "array-curry: The first argument is not an array: " array right-dimension))
-	((not (exact-integer? right-dimension))
-	 (error "array-curry: The second argument is not an exact integer: " array right-dimension))
-	((not (< 0 right-dimension (%%interval-dimension (array-domain array))))
-	 (error "array-curry: The second argument is not between 0 and (interval-dimension (array-domain array)) (exclusive): " array right-dimension))
-	((specialized-array? array)
-	 (%%specialized-array-curry array right-dimension))
-	((mutable-array? array)
-	 (%%mutable-array-curry array right-dimension))
-	(else ; immutable array
-	 (%%immutable-array-curry array right-dimension))))
+         (error "array-curry: The first argument is not an array: " array right-dimension))
+        ((not (exact-integer? right-dimension))
+         (error "array-curry: The second argument is not an exact integer: " array right-dimension))
+        ((not (< 0 right-dimension (%%interval-dimension (array-domain array))))
+         (error "array-curry: The second argument is not between 0 and (interval-dimension (array-domain array)) (exclusive): " array right-dimension))
+        ((specialized-array? array)
+         (%%specialized-array-curry array right-dimension))
+        ((mutable-array? array)
+         (%%mutable-array-curry array right-dimension))
+        (else ; immutable array
+         (%%immutable-array-curry array right-dimension))))
 
 ;;;
 ;;; array-map returns an array whose domain is the same as the common domain of (cons array arrays)
@@ -2777,86 +2746,86 @@
 
 (define (%%specialize-function-applied-to-array-getters f array arrays)
   (let ((domain (%%array-domain array))
-	(getter-0 (%%array-getter array)))
+        (getter-0 (%%array-getter array)))
     (case (length arrays)
       ((0) (case (%%interval-dimension domain)
-	     ((1)  (lambda (i)         (f (getter-0 i))))
-	     ((2)  (lambda (i j)       (f (getter-0 i j))))
-	     ((3)  (lambda (i j k)     (f (getter-0 i j k))))
-	     ((4)  (lambda (i j k l)   (f (getter-0 i j k l))))
-	     (else (lambda multi-index (f (apply getter-0 multi-index))))))
+             ((1)  (lambda (i)         (f (getter-0 i))))
+             ((2)  (lambda (i j)       (f (getter-0 i j))))
+             ((3)  (lambda (i j k)     (f (getter-0 i j k))))
+             ((4)  (lambda (i j k l)   (f (getter-0 i j k l))))
+             (else (lambda multi-index (f (apply getter-0 multi-index))))))
 
       ((1) (let ((getter-1 (%%array-getter (car arrays))))
-	     (case (%%interval-dimension domain)
-	       ((1)  (lambda (i)         (f (getter-0 i)
-					    (getter-1 i))))
-	       ((2)  (lambda (i j)       (f (getter-0 i j)
-					    (getter-1 i j))))
-	       ((3)  (lambda (i j k)     (f (getter-0 i j k)
-					    (getter-1 i j k))))
-	       ((4)  (lambda (i j k l)   (f (getter-0 i j k l)
-					    (getter-1 i j k l))))
-	       (else (lambda multi-index (f (apply getter-0 multi-index)
-					    (apply getter-1 multi-index)))))))
+             (case (%%interval-dimension domain)
+               ((1)  (lambda (i)         (f (getter-0 i)
+                                            (getter-1 i))))
+               ((2)  (lambda (i j)       (f (getter-0 i j)
+                                            (getter-1 i j))))
+               ((3)  (lambda (i j k)     (f (getter-0 i j k)
+                                            (getter-1 i j k))))
+               ((4)  (lambda (i j k l)   (f (getter-0 i j k l)
+                                            (getter-1 i j k l))))
+               (else (lambda multi-index (f (apply getter-0 multi-index)
+                                            (apply getter-1 multi-index)))))))
       ((2) (let ((getter-1 (%%array-getter (car arrays)))
-		 (getter-2 (%%array-getter (cadr arrays))))
-	     (case (%%interval-dimension domain)
-	       ((1)  (lambda (i)         (f (getter-0 i)
-					    (getter-1 i)
-					    (getter-2 i))))
-	       ((2)  (lambda (i j)       (f (getter-0 i j)
-					    (getter-1 i j)
-					    (getter-2 i j))))
-	       ((3)  (lambda (i j k)     (f (getter-0 i j k)
-					    (getter-1 i j k)
-					    (getter-2 i j k))))
-	       ((4)  (lambda (i j k l)   (f (getter-0 i j k l)
-					    (getter-1 i j k l)
-					    (getter-2 i j k l))))
-	       (else (lambda multi-index (f (apply getter-0 multi-index)
-					    (apply getter-1 multi-index)
-					    (apply getter-2 multi-index)))))))
+                 (getter-2 (%%array-getter (cadr arrays))))
+             (case (%%interval-dimension domain)
+               ((1)  (lambda (i)         (f (getter-0 i)
+                                            (getter-1 i)
+                                            (getter-2 i))))
+               ((2)  (lambda (i j)       (f (getter-0 i j)
+                                            (getter-1 i j)
+                                            (getter-2 i j))))
+               ((3)  (lambda (i j k)     (f (getter-0 i j k)
+                                            (getter-1 i j k)
+                                            (getter-2 i j k))))
+               ((4)  (lambda (i j k l)   (f (getter-0 i j k l)
+                                            (getter-1 i j k l)
+                                            (getter-2 i j k l))))
+               (else (lambda multi-index (f (apply getter-0 multi-index)
+                                            (apply getter-1 multi-index)
+                                            (apply getter-2 multi-index)))))))
       ((3) (let ((getter-1 (%%array-getter (car arrays)))
-		 (getter-2 (%%array-getter (cadr arrays)))
+                 (getter-2 (%%array-getter (cadr arrays)))
                  (getter-3 (%%array-getter (caddr arrays))))
-	     (case (%%interval-dimension domain)
-	       ((1)  (lambda (i)         (f (getter-0 i)
-					    (getter-1 i)
-					    (getter-2 i)
+             (case (%%interval-dimension domain)
+               ((1)  (lambda (i)         (f (getter-0 i)
+                                            (getter-1 i)
+                                            (getter-2 i)
                                             (getter-3 i))))
-	       ((2)  (lambda (i j)       (f (getter-0 i j)
-					    (getter-1 i j)
-					    (getter-2 i j)
+               ((2)  (lambda (i j)       (f (getter-0 i j)
+                                            (getter-1 i j)
+                                            (getter-2 i j)
                                             (getter-3 i j))))
-	       ((3)  (lambda (i j k)     (f (getter-0 i j k)
-					    (getter-1 i j k)
-					    (getter-2 i j k)
+               ((3)  (lambda (i j k)     (f (getter-0 i j k)
+                                            (getter-1 i j k)
+                                            (getter-2 i j k)
                                             (getter-3 i j k))))
-	       ((4)  (lambda (i j k l)   (f (getter-0 i j k l)
-					    (getter-1 i j k l)
-					    (getter-2 i j k l)
+               ((4)  (lambda (i j k l)   (f (getter-0 i j k l)
+                                            (getter-1 i j k l)
+                                            (getter-2 i j k l)
                                             (getter-3 i j k l))))
-	       (else (lambda multi-index (f (apply getter-0 multi-index)
-					    (apply getter-1 multi-index)
-					    (apply getter-2 multi-index)
+               (else (lambda multi-index (f (apply getter-0 multi-index)
+                                            (apply getter-1 multi-index)
+                                            (apply getter-2 multi-index)
                                             (apply getter-3 multi-index)))))))
       (else
        (let ((getters (cons getter-0 (map array-getter arrays))))
-	 (case (%%interval-dimension domain)
-	   ((1)  (lambda (i)         (apply f (map (lambda (g) (g i))                 getters))))
-	   ((2)  (lambda (i j)       (apply f (map (lambda (g) (g i j))               getters))))
-	   ((3)  (lambda (i j k)     (apply f (map (lambda (g) (g i j k))             getters))))
-	   ((4)  (lambda (i j k l)   (apply f (map (lambda (g) (g i j k l))           getters))))
-	   (else (lambda multi-index (apply f (map (lambda (g) (apply g multi-index)) getters))))))))))
+         (case (%%interval-dimension domain)
+           ((1)  (lambda (i)         (apply f (map (lambda (g) (g i))                 getters))))
+           ((2)  (lambda (i j)       (apply f (map (lambda (g) (g i j))               getters))))
+           ((3)  (lambda (i j k)     (apply f (map (lambda (g) (g i j k))             getters))))
+           ((4)  (lambda (i j k l)   (apply f (map (lambda (g) (g i j k l))           getters))))
+           (else (lambda multi-index (apply f (map (lambda (g) (apply g multi-index)) getters))))))))))
 
 (define (array-map f array #!rest arrays)
   (cond ((not (procedure? f))
-	 (apply error "array-map: The first argument is not a procedure: " f array arrays))
-	((not (%%every array? (cons array arrays)))
-	 (apply error "array-map: Not all arguments after the first are arrays: " f array arrays))
-	((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
-	 (apply error "array-map: Not all arguments after the first have the same domain: " f array arrays))
-	(else
+         (apply error "array-map: The first argument is not a procedure: " f array arrays))
+        ((not (%%every array? (cons array arrays)))
+         (apply error "array-map: Not all arguments after the first are arrays: " f array arrays))
+        ((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
+         (apply error "array-map: Not all arguments after the first have the same domain: " f array arrays))
+        (else
          (make-array (%%array-domain array)
                      (%%specialize-function-applied-to-array-getters f array arrays)))))
 
@@ -2864,13 +2833,13 @@
 
 (define (array-for-each f array #!rest arrays)
   (cond ((not (procedure? f))
-	 (apply error "array-for-each: The first argument is not a procedure: " f array arrays))
-	((not (%%every array? (cons array arrays)))
-	 (apply error "array-for-each: Not all arguments after the first are arrays: " f array arrays))
-	((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
-	 (apply error "array-for-each: Not all arguments after the first have the same domain: " f array arrays))
-	(else
-	 (%%interval-for-each (%%specialize-function-applied-to-array-getters f array arrays)
+         (apply error "array-for-each: The first argument is not a procedure: " f array arrays))
+        ((not (%%every array? (cons array arrays)))
+         (apply error "array-for-each: Not all arguments after the first are arrays: " f array arrays))
+        ((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
+         (apply error "array-for-each: Not all arguments after the first have the same domain: " f array arrays))
+        (else
+         (%%interval-for-each (%%specialize-function-applied-to-array-getters f array arrays)
                               (%%array-domain array)))))
 
 (define-macro (macro-make-predicates)
@@ -3021,23 +2990,23 @@
 
 (define (array-every f array #!rest arrays)
   (cond ((not (procedure? f))
-	 (apply error "array-every: The first argument is not a procedure: " f array arrays))
-	((not (%%every array? (cons array arrays)))
-	 (apply error "array-every: Not all arguments after the first are arrays: " f array arrays))
-	((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
-	 (apply error "array-every: Not all arguments after the first have the same domain: " f array arrays))
-	(else
+         (apply error "array-every: The first argument is not a procedure: " f array arrays))
+        ((not (%%every array? (cons array arrays)))
+         (apply error "array-every: Not all arguments after the first are arrays: " f array arrays))
+        ((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
+         (apply error "array-every: Not all arguments after the first have the same domain: " f array arrays))
+        (else
          (%%interval-every (%%specialize-function-applied-to-array-getters f array arrays)
                            (%%array-domain array)))))
 
 (define (array-any f array #!rest arrays)
   (cond ((not (procedure? f))
-	 (apply error "array-any: The first argument is not a procedure: " f array arrays))
-	((not (%%every array? (cons array arrays)))
-	 (apply error "array-any: Not all arguments after the first are arrays: " f array arrays))
-	((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
-	 (apply error "array-any: Not all arguments after the first have the same domain: " f array arrays))
-	(else
+         (apply error "array-any: The first argument is not a procedure: " f array arrays))
+        ((not (%%every array? (cons array arrays)))
+         (apply error "array-any: Not all arguments after the first are arrays: " f array arrays))
+        ((not (%%every (lambda (d) (%%interval= d (%%array-domain array))) (map %%array-domain arrays)))
+         (apply error "array-any: Not all arguments after the first have the same domain: " f array arrays))
+        (else
          (%%interval-any (%%specialize-function-applied-to-array-getters f array arrays)
                          (%%array-domain array)))))
 
@@ -3047,19 +3016,19 @@
 
 (define (array-fold op id a)
   (cond ((not (procedure? op))
-	 (error "array-fold: The first argument is not a procedure: " op id a))
-	((not (array? a))
-	 (error "array-fold: The third argument is not an array: " op id a))
-	(else
-	 (%%array-fold op id a))))
+         (error "array-fold: The first argument is not a procedure: " op id a))
+        ((not (array? a))
+         (error "array-fold: The third argument is not an array: " op id a))
+        (else
+         (%%array-fold op id a))))
 
 (define (array-fold-right op id a)
   (cond ((not (procedure? op))
-	 (error "array-fold-right: The first argument is not a procedure: " op id a))
-	((not (array? a))
-	 (error "array-fold-right: The third argument is not an array: " op id a))
-	(else
-	 (%%array-fold op id (array-reverse a (make-vector (%%array-dimension a) #t))))))
+         (error "array-fold-right: The first argument is not a procedure: " op id a))
+        ((not (array? a))
+         (error "array-fold-right: The third argument is not an array: " op id a))
+        (else
+         (%%array-fold op id (array-reverse a (make-vector (%%array-dimension a) #t))))))
 
 (define (array-reduce sum A)
   (cond ((not (array? A))
@@ -3070,7 +3039,7 @@
          (case (%%array-dimension A)
            ((1) (let ((box '())
                       (A_ (%%array-getter A)))
-                  (interval-for-each
+                  (%%interval-for-each
                    (lambda (i)
                      (if (null? box)
                          (set! box (list (A_ i)))
@@ -3080,7 +3049,7 @@
                   (car box)))
            ((2) (let ((box '())
                       (A_ (%%array-getter A)))
-                  (interval-for-each
+                  (%%interval-for-each
                    (lambda (i j)
                      (if (null? box)
                          (set! box (list (A_ i j)))
@@ -3090,7 +3059,7 @@
                   (car box)))
            ((3) (let ((box '())
                       (A_ (%%array-getter A)))
-                  (interval-for-each
+                  (%%interval-for-each
                    (lambda (i j k)
                      (if (null? box)
                          (set! box (list (A_ i j k)))
@@ -3100,7 +3069,7 @@
                   (car box)))
            ((4) (let ((box '())
                       (A_ (%%array-getter A)))
-                  (interval-for-each
+                  (%%interval-for-each
                    (lambda (i j k l)
                      (if (null? box)
                          (set! box (list (A_ i j k l)))
@@ -3110,7 +3079,7 @@
                   (car box)))
            (else (let ((box '())
                        (A_ (%%array-getter A)))
-                   (interval-for-each
+                   (%%interval-for-each
                     (lambda args
                       (if (null? box)
                           (set! box (list (apply A_ args)))
@@ -3121,9 +3090,9 @@
 
 (define (array->list array)
   (cond ((not (array? array))
-	 (error "array->list: The argument is not an array: " array))
- 	(else
-	 (array-fold-right cons '() array))))
+         (error "array->list: The argument is not an array: " array))
+        (else
+         (array-fold-right cons '() array))))
 
 (define (list->specialized-array l
                                  interval
@@ -3132,44 +3101,44 @@
                                  (mutable? (specialized-array-default-mutable?))
                                  (safe? (specialized-array-default-safe?)))
   (cond ((not (list? l))
-	 (error "list->specialized-array: The first argument is not a list: " l interval))
-	((not (interval? interval))
-	 (error "list->specialized-array: The second argument is not an interval: " l interval))
-	((not (storage-class? result-storage-class))
-	 (error "list->specialized-array: The third argument is not a storage-class: " l interval result-storage-class))
-	((not (boolean? mutable?))
-	 (error "list->specialized-array: The fourth argument is not a boolean: " l interval result-storage-class mutable?))
+         (error "list->specialized-array: The first argument is not a list: " l interval))
+        ((not (interval? interval))
+         (error "list->specialized-array: The second argument is not an interval: " l interval))
+        ((not (storage-class? result-storage-class))
+         (error "list->specialized-array: The third argument is not a storage-class: " l interval result-storage-class))
+        ((not (boolean? mutable?))
+         (error "list->specialized-array: The fourth argument is not a boolean: " l interval result-storage-class mutable?))
         ((not (boolean? safe?))
-	 (error "list->specialized-array: The fifth argument is not a boolean: " l interval result-storage-class mutable? safe?))
-	(else
-	 (let* ((checker
-		 (storage-class-checker  result-storage-class))
-		(setter
-		 (storage-class-setter   result-storage-class))
-		(result
-		 (%%make-specialized-array interval
+         (error "list->specialized-array: The fifth argument is not a boolean: " l interval result-storage-class mutable? safe?))
+        (else
+         (let* ((checker
+                 (storage-class-checker  result-storage-class))
+                (setter
+                 (storage-class-setter   result-storage-class))
+                (result
+                 (%%make-specialized-array interval
                                            result-storage-class
                                            safe?))
-		(body
-		 (%%array-body result))
-		(n
-		 (interval-volume interval)))
-	   (let loop ((i 0)
-		      (local l))
-	     (if (or (= i n) (null? local))
-		 (if (and (= i n) (null? local))
-		     (begin
+                (body
+                 (%%array-body result))
+                (n
+                 (interval-volume interval)))
+           (let loop ((i 0)
+                      (local l))
+             (if (or (= i n) (null? local))
+                 (if (and (= i n) (null? local))
+                     (begin
                        (if (not mutable?)
                            (%%array-setter-set! result #f))
                        result)
-		     (error "list->specialized-array: The length of the first argument does not equal the volume of the second: " l interval))
-		 (let ((item (car local)))
-		   (if (checker item)
-		       (begin
-			 (setter body i item)
-			 (loop (+ i 1)
-			       (cdr local)))
-		       (error "list->specialized-array: Not every element of the list can be stored in the body of the array: " l interval item)))))))))
+                     (error "list->specialized-array: The length of the first argument does not equal the volume of the second: " l interval))
+                 (let ((item (car local)))
+                   (if (checker item)
+                       (begin
+                         (setter body i item)
+                         (loop (+ i 1)
+                               (cdr local)))
+                       (error "list->specialized-array: Not every element of the list can be stored in the body of the array: " l interval item)))))))))
 
 (define (array-assign! destination source)
   (cond ((not (mutable-array? destination))
@@ -3192,8 +3161,8 @@
                       (%%array-storage-class source))
               ;; does a copier for this storage-class exist?
               (storage-class-copier (%%array-storage-class destination))
-              (array-elements-in-order? destination)
-              (array-elements-in-order? source))
+              (%%array-elements-in-order? destination)
+              (%%array-elements-in-order? source))
          ;; do a block copy
          (let* ((source-indexer
                  (array-indexer source))
@@ -3222,7 +3191,7 @@
                 (%%array-setter destination))
                (domain
                 (%%array-domain destination)))
-           (interval-for-each
+           (%%interval-for-each
             (case (interval-dimension domain)
               ((1) (lambda (i)
                      (destination-setter (source-getter i)
@@ -3256,7 +3225,7 @@
                (A! (%%array-setter A))
                (B_ (%%array-getter B))
                (B! (%%array-setter B)))
-           (interval-for-each
+           (%%interval-for-each
             (case (%%array-dimension A)
               ((1) (lambda (i)
                      (let ((temp (A_ i)))
@@ -3282,7 +3251,7 @@
             (%%array-domain A))))))
 
 ;;; Because array-ref and array-set! have variable number of arguments, and
-;;; they have to check that the first argument is an array on every call,
+;;; they have to check on every call that the first argument is an array,
 ;;; compiled code using array-ref and array-set! can take up to three times
 ;;; as long as our usual notational convention:
 ;;;

--- a/srfi-179.html
+++ b/srfi-179.html
@@ -26,7 +26,8 @@
       <li>Draft #3 published: 2020-02-04</li>
       <li>Draft #4 published: 2020-03-25</li>
       <li>Draft #5 published: 2020-04-30</li>
-      <li>Draft #6 published: 2020-05-03</li></ul>
+      <li>Draft #6 published: 2020-05-03</li>
+      <li>Draft #7 published: 2020-05-09</li></ul>
     <h2>Abstract</h2>
     <p>This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a mapping, or function, from multi-indices of exact integers $i_0,\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices $i_0,\ldots,i_{d-1}$ that are valid for a given array form the <i>domain</i> of the array.  In this SRFI, each array's domain consists  of the cross product of nonempty intervals of exact integers $[l_0,u_0)\times[l_1,u_1)\times\cdots\times[l_{d-1},u_{d-1})$ of $\mathbb Z^d$, $d$-tuples of integers.  Thus, we introduce a data type called $d$-<i>intervals</i>, or more briefly <i>intervals</i>, that encapsulates this notion. (We borrow this terminology from, e.g.,  Elias Zakon's <a href="http://www.trillia.com/zakon1.html">Basic Concepts of Mathematics</a>.) Specialized variants of arrays are specified to provide portable programs with efficient representations for common use cases.</p>
     <h2>Rationale</h2>
@@ -35,7 +36,7 @@
       <li>Provide a <b>general API</b> (Application Program Interface) that specifies the minimal required properties of any given array, without requiring any specific implementation strategy from the programmer for that array.</li>
       <li>Provide a <b>single, efficient implementation for dense arrays</b> (which we call <i>specialized arrays</i>).</li>
       <li>Provide <b>useful array transformations</b> by exploiting the algebraic structure of affine one-to-one mappings on multi-indices.</li>
-      <li>Separate <b>the routines that specify the work to be done</b> (<code>array-map</code>, <code>array-outer-product</code>, etc.) from <b>the routines that actually do the work</b> (<code>array-&gt;specialized-array</code>, <code>array-assign!</code>, <code>array-fold</code>, etc.). This approach <b>avoids temporary intermediate arrays</b> in computations.</li>
+      <li>Separate <b>the routines that specify the work to be done</b> (<code>array-map</code>, <code>array-outer-product</code>, etc.) from <b>the routines that actually do the work</b> (<code>array-copy</code>, <code>array-assign!</code>, <code>array-fold</code>, etc.). This approach <b>avoids temporary intermediate arrays</b> in computations.</li>
       <li>Encourage <b>bulk processing of arrays</b> rather than word-by-word operations.</li></ul>
     <p>This SRFI differs from the finalized <a href="https://srfi.schemers.org/srfi-122/">SRFI 122</a> in the following ways:</p>
     <ul>
@@ -87,7 +88,7 @@
     <p>Thus, while we do not provide for sharing of generalized arrays for general one-to-one affine maps $T$, we do allow it for the specific functions <code>array-extract</code>, <code>array-translate</code>, <code>array-permute</code>,  <code>array-curry</code>,  <code>array-reverse</code>, <code>array-tile</code>, <code>array-rotate</code> and <code>array-sample</code>,  and we provide relatively efficient implementations of these functions for arrays of dimension no greater than four.</p>
     <h3>Array-map does not produce a specialized array</h3>
     <p>Daniel Friedman and David Wise wrote a famous paper <a href="http://www.cs.indiana.edu/cgi-bin/techreports/TRNNN.cgi?trnum=TR44">CONS should not Evaluate its Arguments</a>. In the spirit of that paper, our procedure <code>array-map</code> does not immediately produce a specialized array, but a simple immutable array, whose elements are recomputed from the arguments of <code>array-map</code> each time they are accessed.   This immutable array can be passed on to further applications of <code>array-map</code> for further processing, without generating the storage bodies for intermediate arrays.</p>
-    <p>We provide the procedure <code>array-&gt;specialized-array</code> to transform a generalized array (like that returned by <code>array-map</code>) to a specialized, Bawden-style array, for which accessing each element again takes $O(1)$ operations.</p>
+    <p>We provide the procedure <code>array-copy</code> to transform a generalized array (like that returned by <code>array-map</code>) to a specialized, Bawden-style array, for which accessing each element again takes $O(1)$ operations.</p>
     <h3>Notational convention</h3>
     <p>If <code><var>A</var></code> is an array, then we generally define <code><var>A_</var></code> to be <code>(array-getter <var>A</var>)</code> and  <code><var>A!</var></code> to be <code>(array-setter <var>A</var>)</code>.  The latter notation is motivated by the general Scheme convention that the names of functions that modify the contents of data structures end in <code><var>!</var></code>, while the notation for the getter of an array is motivated by the TeX notation for subscripts.  See particularly the <a href="#Haar">Haar transform</a> example.</p>
     <h2>Issues and Notes</h2>
@@ -101,7 +102,7 @@
       <li><b>Choice of functions on intervals. </b>The choice of functions for both arrays and intervals was motivated almost solely by what I needed for arrays.</li>
       <li><b>No empty intervals. </b>This SRFI considers arrays over only nonempty intervals of positive dimension.  The author of this proposal acknowledges that other languages and array systems allow either zero-dimensional intervals or empty intervals of positive dimension, but prefers to leave such empty intervals as possibly compatible extensions to the current proposal.</li>
       <li><b>Multi-valued arrays. </b>While this SRFI restricts attention to single-valued arrays, wherein the getter of each array returns a single value, allowing multi-valued immutable arrays would a compatible extension of this SRFI.</li>
-      <li><b>No low-level specialized-array constructor. </b>While the author of the SRFI uses mainly <code>(make-array ...)</code>, <code>array-map</code>, and <code>array-&gt;specialized-array</code> to construct arrays, and while there are several other ways to construct arrays, there is no really low-level interface given for constructing specialized arrays (where one specifies a body, an indexer, etc.).  It was felt that certain difficulties, some surmountable (such as checking that a given body is compatible with a given storage class) and some not (such as checking that an indexer is indeed affine), made a low-level interface less useful.  At the same time, the simple <code>(make-array ...)</code> mechanism is so general, allowing one to specify getters and setters as general functions, as to cover nearly all needs.</li></ul>
+      <li><b>No low-level specialized-array constructor. </b>While the author of the SRFI uses mainly <code>(make-array ...)</code>, <code>array-map</code>, and <code>array-copy</code> to construct arrays, and while there are several other ways to construct arrays, there is no really low-level interface given for constructing specialized arrays (where one specifies a body, an indexer, etc.).  It was felt that certain difficulties, some surmountable (such as checking that a given body is compatible with a given storage class) and some not (such as checking that an indexer is indeed affine), made a low-level interface less useful.  At the same time, the simple <code>(make-array ...)</code> mechanism is so general, allowing one to specify getters and setters as general functions, as to cover nearly all needs.</li></ul>
     <h2>Specification</h2>
     <dl>
       <dt>Miscellaneous Functions</dt>
@@ -174,7 +175,7 @@
         <a href="#array-safe?">array-safe?</a>,
         <a href="#array-elements-in-order?">array-elements-in-order?</a>,
         <a href="#specialized-array-share">specialized-array-share</a>,
-        <a href="#array-&gt;specialized-array">array-&gt;specialized-array</a>,
+        <a href="#array-copy">array-copy</a>,
         <a href="#array-curry">array-curry</a>,
         <a href="#array-extract">array-extract</a>,
         <a href="#array-tile">array-tile</a>,
@@ -628,7 +629,7 @@ indexer:       (lambda multi-index
     <p><b>Example: </b>One can apply a &quot;shearing&quot; operation to an array as follows: </p>
     <pre><code>
 (define a
-  (array-&gt;specialized-array
+  (array-copy
    (make-array (make-interval '#(5 10))
                list)))
 (define b
@@ -650,21 +651,19 @@ indexer:       (lambda multi-index
 ;; ((4 4) (4 5) (4 6) (4 7) (4 8))
 </code></pre>
     <p>This &quot;shearing&quot; operation cannot be achieved by combining the procedures <code>array-extract</code>, <code>array-translate</code>, <code>array-permute</code>, <code>array-translate</code>, <code>array-curry</code>, <code>array-reverse</code>, and <code>array-sample</code>.</p>
-    <p><b>Procedure: </b><code><a name="array-&gt;specialized-array">array-&gt;specialized-array</a> <var>array</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
-    <p>If <code><var>array</var></code> is an array whose elements can be manipulated by the storage-class
-      <code><var>result-storage-class</var></code>, then the specialized-array returned by <code>array-&gt;specialized-array</code> can be defined conceptually by:</p>
+    <p><b>Procedure: </b><code><a name="array-copy">array-copy</a> <var>array</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>new-domain</var> #f ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
+    <p>Assumes that <code><var>array</var></code> is an array, <code><var>result-storage-class</var></code> is a storage class that can manipulate all the elements of <code><var>array</var></code>, <code><var>new-domain</var></code> is either <code>#f</code> or an interval with the same volume as <code>(array-domain <var>array</var>)</code>, and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
+    <p>If <code><var>new-domain</var></code> is <code>#f</code>, then it is set to <code>(array-domain <var>array</var>)</code>. </p>
+    <p>The specialized array returned by <code>array-copy</code> can be defined conceptually by:</p>
     <pre><code>
-(let* ((domain
-        (array-domain <var>array</var>))
-       (result
-        (make-specialized-array domain
-                                <var>result-storage-class</var>
-                                <var>safe?</var>)))
-  (array-assign! result <var>array</var>)
-  result)</code></pre>
-    <p>If <code><var>mutable?</var></code> is <code>#f</code>, then the setter of the resulting array is set to <code>#f</code>.</p>
-    <p>It is guaranteed that <code>(array-getter <var>array</var>)</code> is called precisely once for each multi-index in <code>(array-domain <var>array</var>)</code> in lexicographical order.</p>
-    <p>It is an error if <code><var>result-storage-class</var></code> does not satisfy these conditions, or if <code><var>safe?</var></code> or <code><var>mutable?</var></code> are not booleans.</p>
+(list-&gt;specialized-array (array-&gt;list array)
+                         new-domain
+                         result-storage-class
+                         mutable?
+                         safe?)
+</code></pre>
+    <p>It is an error if the arguments do not satisfy these conditions.</p>
+    <p><b>Note: </b>If <code><var>new-domain</var></code> is not the same as <code>(array-domain <var>array</var>)</code>, one can think of the resulting array as a <i>reshaped</i> version of <code><var>array</var></code>.</p>
     <p><b>Procedure: </b><code><a name="array-curry">array-curry</a> <var>array</var> <var>inner-dimension</var></code></p>
     <p>If <code><var>array</var></code> is an array whose domain is an interval  $[l_0,u_0)\times\cdots\times[l_{d-1},u_{d-1})$, and <code><var>inner-dimension</var></code> is an exact integer strictly between $0$ and $d$, then <code>array-curry</code> returns an immutable array with domain $[l_0,u_0)\times\cdots\times[l_{d-\text{inner-dimension}-1},u_{d-\text{inner-dimension}-1})$, each of whose entries is in itself an array with domain $[l_{d-\text{inner-dimension}},u_{d-\text{inner-dimension}})\times\cdots\times[l_{d-1},u_{d-1})$.</p>
     <p>For example, if <code>A</code> and <code>B</code> are defined by </p>
@@ -1141,9 +1140,11 @@ indexer:       (lambda multi-index
     <p>It is an error if the arguments do not satisfy these assumptions.</p>
     <p><b>Procedure: </b><code><a name="array-&gt;list">array-&gt;list</a> <var>array</var></code></p>
     <p>Stores the elements of <code><var>array</var></code> into a newly allocated list in lexicographical order.  It is an error if <code><var>array</var></code> is not an array.</p>
-    <p><b>Procedure: </b><code><a name="list-&gt;specialized-array">list-&gt;specialized-array</a> <var>l</var> <var>interval</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
-    <p>Returns a specialized-array with domain <code><var>interval</var></code> whose elements are the elements of the list <code><var>l</var></code> stored in lexicographical order.  It is an error if <code><var>l</var></code> is not a list, if <code><var>interval</var></code> is not an interval, if the length of <code><var>l</var></code> is not the same as the volume of  <code><var>interval</var></code>, if <code><var>result-storage-class</var></code> (when given) is not a storage class, if <code><var>mutable?</var></code> (when given) is not a boolean, if <code><var>safe?</var></code> (when given) is not a boolean, or if any element of  <code><var>l</var></code> cannot be stored in the body of <code><var>result-storage-class</var></code>, and this last error shall be detected and raised.</p>
-    <p>If <code><var>mutable?</var></code> is <code>#f</code>, then the setter of the resulting array is set to <code>#f</code>.</p>
+    <p>It is guaranteed that <code>(array-getter <var>array</var>)</code> is called precisely once for each multi-index in <code>(array-domain <var>array</var>)</code> in lexicographical order.</p>
+    <p><b>Procedure: </b><code><a name="list-&gt;specialized-array">list-&gt;specialized-array</a> <var>l</var> <var>domain</var> [ <var>result-storage-class</var> generic-storage-class ] [ <var>mutable?</var> (specialized-array-default-mutable?) ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
+    <p>Assumes that <code><var>l</var></code> is an list, <code><var>domain</var></code> is an interval with volume the same as the length of <code><var>l</var></code>,  <code><var>result-storage-class</var></code> is a storage class that can manipulate all the elements of <code><var>l</var></code>, and <code><var>mutable?</var></code> and <code><var>safe?</var></code> are booleans.</p>
+    <p>Returns a specialized-array with domain <code><var>domain</var></code> whose elements are the elements of the list <code><var>l</var></code> stored in lexicographical order.  The result is mutable or safe depending on the values of <code><var>mutable?</var></code> and <code><var>safe?</var></code>.</p>
+    <p>It is an error if the arguments do not satisfy these assumptions, or if any element of  <code><var>l</var></code> cannot be stored in the body of <code><var>result-storage-class</var></code>, and this last error shall be detected and raised.</p>
     <p><b>Procedure: </b><code><a name="array-assign!">array-assign!</a> <var>destination</var> <var>source</var></code></p>
     <p>Assumes that <code><var>destination</var></code> is a mutable array and <code><var>source</var></code> is an array, both with the same domains, and that the elements of <code><var>source</var></code> can be stored into <code><var>destination</var></code>.</p>
     <p>Evaluates <code>(array-getter <var>source</var>)</code> on the multi-indices in <code>(array-domain <var>source</var>)</code> in an unspecified order, and associates each value to the same multi-index in <code><var>destination</var></code>.</p>
@@ -1198,7 +1199,7 @@ indexer:       (lambda multi-index
     <p>Image processing applications provided significant motivation for this SRFI.</p>
     <p><b>Manipulating images in PGM format. </b>On a system with eight-bit chars, one
       can write routines to read and write greyscale images in the PGM format of the netpbm package as follows.  The  lexicographical
-      order in array-&gt;specialized-array guarantees the the correct order of execution of the input procedures:</p>
+      order in <code>array-copy</code> guarantees the the correct order of execution of the input procedures:</p>
     <pre><code>
 (define make-pgm   cons)
 (define pgm-greys  car)
@@ -1269,7 +1270,7 @@ indexer:       (lambda multi-index
 
         (make-pgm
          greys
-         (array-&gt;specialized-array
+         (array-copy
           (make-array
            (make-interval (vector rows columns))
            (cond ((or (eq? header 'p5)
@@ -1421,7 +1422,7 @@ indexer:       (lambda multi-index
 
 (let* ((greys (pgm-greys test-pgm))
        (edge-array
-        (array-&gt;specialized-array
+        (array-copy
          (array-map
           abs
           (array-convolve
@@ -1472,7 +1473,7 @@ indexer:       (lambda multi-index
                  (loop
                   (+ i 1)
                   (cons
-                   (array-&gt;specialized-array
+                   (array-copy
                     (array-map
                      (lambda (f_i f_i+d f_i+2d)
                        (+ f_i+2d
@@ -1498,7 +1499,7 @@ indexer:       (lambda multi-index
     <p>We can define a small synthetic image of size 8x8 pixels and compute its second differences in various directions: </p>
     <pre><code>
 (define image
- (array-&gt;specialized-array
+ (array-copy
   (make-array (make-interval '#(8 8))
               (lambda (i j)
                 (exact-&gt;inexact (+ (* i i) (* j j)))))))
@@ -1628,7 +1629,7 @@ Second-differences in the direction $k\times (1,-1)$:
     <p>We then define an image that is a multiple of a single, two-dimensional hyperbolic Haar wavelet, compute its hyperbolic Haar transform (which should have only one nonzero coefficient), and then the inverse transform:</p>
     <pre><code>
 (let ((image
-       (array-&gt;specialized-array
+       (array-copy
         (make-array (make-interval '#(4 4))
                     (lambda (i j)
                       (case i
@@ -1682,7 +1683,7 @@ Reconstructed image:
     <p>We can apply the (nonhyperbolic) Haar transform to the same image as follows: </p>
     <pre>
  (let ((image
-       (array-&gt;specialized-array
+       (array-copy
         (make-array (make-interval '#(4 4))
                     (lambda (i j)
                       (case i
@@ -1792,7 +1793,7 @@ Reconstructed image:
     <p>We then define a $4\times 4$ <a href="https://en.wikipedia.org/wiki/Hilbert_matrix">Hilbert matrix</a>:</p>
     <pre><code>
 (define A
-  (array-&gt;specialized-array
+  (array-copy
    (make-array (make-interval '#(4 4))
                (lambda (i j)
                  (/ (+ 1 i j))))))

--- a/srfi-179.html
+++ b/srfi-179.html
@@ -194,7 +194,10 @@
         <a href="#array-&gt;list">array-&gt;list</a>,
         <a href="#list-&gt;specialized-array">list-&gt;specialized-array</a>,
         <a href="#array-assign!">array-assign!</a>,
-        <a href="#array-swap!">array-swap!</a>.</dd></dl>
+        <a href="#array-swap!">array-swap!</a>,
+        <a href="#array-ref">array-ref</a>,
+        <a href="#array-set!">array-set!</a>,
+        .</dd></dl>
     <h2>Miscellaneous Functions</h2>
     <p>This document refers to <i>translations</i> and <i>permutations</i>.
        A translation is a vector of exact integers.  A permutation of dimension $n$
@@ -1152,8 +1155,18 @@ indexer:       (lambda multi-index
     <p>Evaluates <code>(array-getter <var>A</var>)</code> on the multi-indices in <code>(array-domain <var>A</var>)</code> in an unspecified order, and associates each value to the same multi-index in <code><var>B</var></code>; similarly it assigns the values of <code>(array-getter <var>B</var>)</code> applied to the  multi-indices of <code>(array-domain <var>B</var>)</code> to the associated indices in <code><var>A</var></code>.</p>
     <p>It is an error if the arguments don't satisfy these assumptions.</p>
     <p>If assigning any element of <code><var>A</var></code> affects the value of any element of <code><var>B</var></code>, or vice versa, then the result is undefined.</p>
+    <p><b>Procedure: </b><code><a name="array-ref">array-ref</a> <var>A</var> <var>i0</var> . <var>i-tail</var></code></p>
+    <p>Assumes that <code><var>A</var></code> is an array, and every element of <code>(cons <var>i0 i-tail</var>)</code> is an exact integer.</p>
+    <p>Returns <code>(apply (array-getter <var>A</var>) <var>i0 i-tail</var>)</code>.</p>
+    <p>It is an error if <code><var>A</var></code> is not an array, or if the number of arguments specified is not the correct number for <code>(array-getter <var>A</var>)</code>.</p>
+    <p><b>Procedure: </b><code><a name="array-set!">array-set!</a> <var>A</var> <var>v</var> <var>i0</var> . <var>i-tail</var></code></p>
+    <p>Assumes that <code><var>A</var></code> is a mutable array, that <code><var>v</var></code> is a value that can be stored within that array, and that every element of <code>(cons <var>i0 i-tail</var>)</code> is an exact integer.</p>
+    <p>Returns <code>(apply (array-setter <var>A</var>) <var>v i0 i-tail</var>)</code>.</p>
+    <p>It is an error if <code><var>A</var></code> is not a mutable array, if <code>v</code> is not an appropriate value to be stored in that array, or if the number of arguments specified is not the correct number for <code>(array-setter <var>A</var>)</code>.</p>
+    <p><b>Note: </b>In the sample implementation, because <code>array-ref</code> and <code>array-set!</code> take a variable number of arguments and they must check that <code><var>A</var></code> is an array of the appropriate type, programs written in a style using these functions, rather than the style in which <code>1D-Haar-loop</code> is coded below, can take up to three times as long runtime.</p>
+    <p><b>Note: </b>In the sample implementation, checking whether the multi-indices are exact integers and within the domain of the array, and checking whether the value is appropriate for storage into the array, is delegated to the underlying definition of the array argument.  If the argument is a safe specialized array, then these items are checked; if it is an unsafe specialized array, they are not.  If it is a generalized array, it is up to the programmer whether to define the getter and setter of the array to check the correctness of the arguments.</p>
     <h2>Implementation</h2>
-    <p>We provide an implementation in Gambit-C; the nonstandard techniques used
+    <p>We provide an implementation in <a href="https://github.com/gambit/gambit">Gambit Scheme</a>; the nonstandard techniques used
       in the implementation are: DSSSL-style optional and keyword arguments; a
       unique object to indicate absent arguments; <code>define-structure</code>;
       and <code>define-macro</code>.</p>
@@ -1166,18 +1179,18 @@ indexer:       (lambda multi-index
     <dl>
       <dt><code>(array? obj)</code></dt>
       <dd><code>(array? obj)</code></dd>
-      <dt><code>(array-rank a)</code></dt>
-      <dd><code>(array-dimension obj)</code></dd>
+      <dt><code>(array-rank A)</code></dt>
+      <dd><code>(array-dimension A)</code></dd>
       <dt><code>(make-array prototype k1 ...)</code></dt>
-      <dd><code>(make-specialized-array (make-interval (vector 0 ...) (vector k1 ...)) storage-class)</code>.</dd>
-      <dt><code>(make-shared-array array mapper k1 ...)</code></dt>
-      <dd><code>(specialized-array-share array (make-interval (vector 0 ...) (vector k1 ...)) mapper)</code></dd>
-      <dt><code>(array-in-bounds? array index1 ...)</code></dt>
-      <dd><code>(interval-contains-multi-index? (array-domain array) index1 ...)</code></dd>
-      <dt><code>(array-ref array k1 ...)</code></dt>
-      <dd><code>((array-getter array) k1 ...)</code></dd>
-      <dt><code>(array-set! array obj k1 ...)</code></dt>
-      <dd><code>((array-setter array) obj k1 ...)</code></dd></dl>
+      <dd><code>(make-specialized-array (make-interval (vector k1 ...)) storage-class)</code>.</dd>
+      <dt><code>(make-shared-array A mapper k1 ...)</code></dt>
+      <dd><code>(specialized-array-share A (make-interval (vector k1 ...)) mapper)</code></dd>
+      <dt><code>(array-in-bounds? A index1 ...)</code></dt>
+      <dd><code>(interval-contains-multi-index? (array-domain A) index1 ...)</code></dd>
+      <dt><code>(array-ref A k1 ...)</code></dt>
+      <dd><code>(let ((A_ (array-getter A))) ... (A_ k1 ...) ... )</code> or <code>(array-ref A k1 ...)</code></dd>
+      <dt><code>(array-set! A obj k1 ...)</code></dt>
+      <dd><code>(let ((A! (array-setter A))) ... (A! obj k1 ...) ...)</code> or <code>(array-set! A obj k1 ...)</code></dd></dl>
     <p>At the same time, this SRFI has some special features:</p>
     <ul>
       <li>Intervals, used as the domains of arrays in this SRFI, are useful
@@ -1185,7 +1198,8 @@ indexer:       (lambda multi-index
         of arrays and the arrays themselves.</li>
       <li>Intervals can have nonzero lower bounds in each dimension.</li>
       <li>Intervals cannot be empty.</li>
-      <li>Arrays must have a getter, but may have no setter.</li></ul>
+      <li>Arrays must have a getter, but may have no setter.</li>
+      <li>There are many predefined array transformations: <code>array-extract</code>, <code>array-tile</code>, <code>array-translate</code>, <code>array-permute</code>, <code>array-rotate</code>, <code>array-sample</code>, <code>array-reverse</code>.</li></ul>
     <h2>Other examples</h2>
     <p>Image processing applications provided significant motivation for this SRFI.</p>
     <p><b>Manipulating images in PGM format. </b>On a system with eight-bit chars, one

--- a/srfi-179.html
+++ b/srfi-179.html
@@ -39,7 +39,7 @@
       <li>Encourage <b>bulk processing of arrays</b> rather than word-by-word operations.</li></ul>
     <p>This SRFI differs from the finalized <a href="https://srfi.schemers.org/srfi-122/">SRFI 122</a> in the following ways:</p>
     <ul>
-      <li>The procedures <code>specialized-array-default-mutable?</code>, <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>interval-rotate</code> and <code>array-elements-in-order?</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-rotate</code>, <code>array-reduce</code>, <code>array-assign!</code>, <code>array-swap!</code> have been added together with some examples.</li>
+      <li>The procedures <code>specialized-array-default-mutable?</code>, <code>interval-for-each</code>, <code>interval-cartesian-product</code>, <code>interval-rotate</code> and <code>array-elements-in-order?</code>, <code>array-outer-product</code>, <code>array-tile</code>, <code>array-rotate</code>, <code>array-reduce</code>, and <code>array-assign!</code>  have been added together with some examples.</li>
       <li>Global variables <code>f8-storage-class</code> and <code>f16-storage-class</code> have been added.</li>
       <li>Homogeneous storage classes must be implemented using homogeneous vectors, or be defined as <code>#f</code>.</li>
       <li>The procedure <code>make-interval</code> now takes one or two arguments.</li>
@@ -194,7 +194,6 @@
         <a href="#array-&gt;list">array-&gt;list</a>,
         <a href="#list-&gt;specialized-array">list-&gt;specialized-array</a>,
         <a href="#array-assign!">array-assign!</a>,
-        <a href="#array-swap!">array-swap!</a>,
         <a href="#array-ref">array-ref</a>,
         <a href="#array-set!">array-set!</a>,
         .</dd></dl>
@@ -1150,11 +1149,6 @@ indexer:       (lambda multi-index
     <p>Evaluates <code>(array-getter <var>source</var>)</code> on the multi-indices in <code>(array-domain <var>source</var>)</code> in an unspecified order, and associates each value to the same multi-index in <code><var>destination</var></code>.</p>
     <p>It is an error if the arguments don't satisfy these assumptions.</p>
     <p>If assigning any element of <code><var>destination</var></code> affects the value of any element of <code><var>source</var></code>, then the result is undefined.</p>
-    <p><b>Procedure: </b><code><a name="array-swap!">array-swap!</a> <var>A</var> <var>B</var></code></p>
-    <p>Assumes that <code><var>A</var></code> and <code><var>B</var></code> are mutable arrays with the same domain, and that the elements of each of them can get stored in the other.</p>
-    <p>Evaluates <code>(array-getter <var>A</var>)</code> on the multi-indices in <code>(array-domain <var>A</var>)</code> in an unspecified order, and associates each value to the same multi-index in <code><var>B</var></code>; similarly it assigns the values of <code>(array-getter <var>B</var>)</code> applied to the  multi-indices of <code>(array-domain <var>B</var>)</code> to the associated indices in <code><var>A</var></code>.</p>
-    <p>It is an error if the arguments don't satisfy these assumptions.</p>
-    <p>If assigning any element of <code><var>A</var></code> affects the value of any element of <code><var>B</var></code>, or vice versa, then the result is undefined.</p>
     <p><b>Procedure: </b><code><a name="array-ref">array-ref</a> <var>A</var> <var>i0</var> . <var>i-tail</var></code></p>
     <p>Assumes that <code><var>A</var></code> is an array, and every element of <code>(cons <var>i0 i-tail</var>)</code> is an exact integer.</p>
     <p>Returns <code>(apply (array-getter <var>A</var>) <var>i0 i-tail</var>)</code>.</p>

--- a/srfi-179.html
+++ b/srfi-179.html
@@ -1314,24 +1314,24 @@ indexer:       (lambda multi-index
     (lambda (port)
       (let* ((greys
               (pgm-greys pgm-data))
-	     (pgm-array
+             (pgm-array
               (pgm-pixels pgm-data))
-	     (domain
+             (domain
               (array-domain pgm-array))
-	     (rows
+             (rows
               (fx- (interval-upper-bound domain 0)
                    (interval-lower-bound domain 0)))
-	     (columns
+             (columns
               (fx- (interval-upper-bound domain 1)
                    (interval-lower-bound domain 1))))
-	(if force-ascii
-	    (display &quot;P2&quot; port)
-	    (display &quot;P5&quot; port))
-	(newline port)
-	(display columns port) (display  port)
-	(display rows port) (newline port)
-	(display greys port) (newline port)
-	(array-for-each
+        (if force-ascii
+            (display &quot;P2&quot; port)
+            (display &quot;P5&quot; port))
+        (newline port)
+        (display columns port) (display  port)
+        (display rows port) (newline port)
+        (display greys port) (newline port)
+        (array-for-each
          (if force-ascii
              (let ((next-pixel-in-line 1))
                (lambda (p)
@@ -1511,9 +1511,9 @@ indexer:       (lambda multi-index
 
 (define (expose difference-images)
   (pretty-print (map (lambda (difference-image)
-		       (list (array-domain difference-image)
-			     (array-&gt;list difference-image)))
-		     difference-images)))
+                       (list (array-domain difference-image)
+                             (array-&gt;list difference-image)))
+                     difference-images)))
 
 (begin
   (display
@@ -1600,16 +1600,16 @@ Second-differences in the direction $k\times (1,-1)$:
     <pre><code>
 (define (1D-Haar-loop a)
   (let ((a_ (array-getter a))
-	(a! (array-setter a))
-	(n (interval-upper-bound (array-domain a) 0)))
+        (a! (array-setter a))
+        (n (interval-upper-bound (array-domain a) 0)))
     (do ((i 0 (fx+ i 2)))
-	((fx= i n))
+        ((fx= i n))
       (let* ((a_i               (a_ i))
-	     (a_i+1             (a_ (fx+ i 1)))
-	     (scaled-sum        (fl/ (fl+ a_i a_i+1) (flsqrt 2.0)))
-	     (scaled-difference (fl/ (fl- a_i a_i+1) (flsqrt 2.0))))
-	(a! scaled-sum i)
-	(a! scaled-difference (fx+ i 1))))))
+             (a_i+1             (a_ (fx+ i 1)))
+             (scaled-sum        (fl/ (fl+ a_i a_i+1) (flsqrt 2.0)))
+             (scaled-difference (fl/ (fl- a_i a_i+1) (flsqrt 2.0))))
+        (a! scaled-sum i)
+        (a! scaled-difference (fx+ i 1))))))
 
 (define 1D-Haar-transform
   (recursively-apply-transform-and-downsample 1D-Haar-loop))
@@ -1645,15 +1645,15 @@ Second-differences in the direction $k\times (1,-1)$:
 Initial image:
 &quot;)
   (pretty-print (list (array-domain image)
-		      (array-&gt;list image)))
+                      (array-&gt;list image)))
   (hyperbolic-Haar-transform image)
   (display &quot;\nArray of hyperbolic Haar wavelet coefficients: \n&quot;)
   (pretty-print (list (array-domain image)
-		      (array-&gt;list image)))
+                      (array-&gt;list image)))
   (hyperbolic-Haar-inverse-transform image)
   (display &quot;\nReconstructed image: \n&quot;)
   (pretty-print (list (array-domain image)
-		      (array-&gt;list image))))
+                      (array-&gt;list image))))
 </code></pre>
     <p>This yields: </p>
     <pre>
@@ -1697,15 +1697,15 @@ Reconstructed image:
                         (else 0.)))))))
   (display &quot;\nInitial image:\n&quot;)
   (pretty-print (list (array-domain image)
-		      (array-&gt;list image)))
+                      (array-&gt;list image)))
   (Haar-transform image)
   (display &quot;\nArray of Haar wavelet coefficients: \n&quot;)
   (pretty-print (list (array-domain image)
-		      (array-&gt;list image)))
+                      (array-&gt;list image)))
   (Haar-inverse-transform image)
   (display &quot;\nReconstructed image: \n&quot;)
   (pretty-print (list (array-domain image)
-		      (array-&gt;list image))))
+                      (array-&gt;list image))))
 </pre>
     <p>This yields: </p>
     <pre>

--- a/srfi-179.scm
+++ b/srfi-179.scm
@@ -2,17 +2,17 @@
 
 (define (format-lambda-list lst)
   (let ((name (car lst))
-	(arguments (cdr lst)))
+        (arguments (cdr lst)))
     (<p> (<b> "Procedure: ")
-	 (<code> (<a> name: name name)
-		 (map (lambda (arg)
-			(list " " (cond ((symbol? arg)
-					 (<var> arg))
-					((keyword? arg)
-					 arg)
-					(else
-					 arg))))
-		      arguments)))))
+         (<code> (<a> name: name name)
+                 (map (lambda (arg)
+                        (list " " (cond ((symbol? arg)
+                                         (<var> arg))
+                                        ((keyword? arg)
+                                         arg)
+                                        (else
+                                         arg))))
+                      arguments)))))
 
 (define (format-global-variable name)
   (<p> (<b> "Variable: ")
@@ -26,42 +26,42 @@
       (<unprotected> "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">")
       (<html>
        (<head>
-	(<meta> charset: "utf-8")
+        (<meta> charset: "utf-8")
         (<meta> name: 'viewport
                 content: "width=device-width, initial-scale=1")
-	(<title> "Nonempty Intervals and Generalized Arrays (Updated)")
-	(<link> href: "https://srfi.schemers.org/srfi.css"
-		rel: "stylesheet"
+        (<title> "Nonempty Intervals and Generalized Arrays (Updated)")
+        (<link> href: "https://srfi.schemers.org/srfi.css"
+                rel: "stylesheet"
                 type: "text/css")
-	(<script> type: "text/x-mathjax-config" "
+        (<script> type: "text/x-mathjax-config" "
 MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'], ['\\\\(','\\\\)']]}
 });")
-	(<script> crossorigin: "anonymous"
+        (<script> crossorigin: "anonymous"
                   integrity:"sha384-Ra6zh6uYMmH5ydwCqqMoykyf1T/+ZcnOQfFPhDrp2kI4OIxadnhsvvA2vv9A7xYv"
                   type: "text/javascript"
-		  src: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
-	)
+                  src: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML")
+        )
        (<body>
-	(<h1> "Title")
-	(<p> "Nonempty Intervals and Generalized Arrays (Updated)")
+        (<h1> "Title")
+        (<p> "Nonempty Intervals and Generalized Arrays (Updated)")
 
-	(<h2> "Author")
-	(<p> "Bradley J. Lucier")
+        (<h2> "Author")
+        (<p> "Bradley J. Lucier")
 
-	(<h2> "Status")
-	(<p> "This SRFI is currently in " (<em> "draft") " status.  Here is "
-	     (<a> href: "https://srfi.schemers.org/srfi-process.html" "an explanation")
-	     " of each status that a SRFI can hold.  To provide input on this SRFI, please send email to "
-	     (<code> (<a> href: "mailto:srfi+minus+179+at+srfi+dotschemers+dot+org"
-			  "srfi-179@" (<span> class: "antispam" "nospam") "srfi.schemers.org"))
-	     ".  To subscribe to the list, follow "
-	     (<a> href: "https://srfi.schemers.org/srfi-list-subscribe.html" "these instructions")
-	     ".  You can access previous messages via the mailing list "
-	     (<a> href: "https://srfi-email.schemers.org/srfi-179" "archive")".")
+        (<h2> "Status")
+        (<p> "This SRFI is currently in " (<em> "draft") " status.  Here is "
+             (<a> href: "https://srfi.schemers.org/srfi-process.html" "an explanation")
+             " of each status that a SRFI can hold.  To provide input on this SRFI, please send email to "
+             (<code> (<a> href: "mailto:srfi+minus+179+at+srfi+dotschemers+dot+org"
+                          "srfi-179@" (<span> class: "antispam" "nospam") "srfi.schemers.org"))
+             ".  To subscribe to the list, follow "
+             (<a> href: "https://srfi.schemers.org/srfi-list-subscribe.html" "these instructions")
+             ".  You can access previous messages via the mailing list "
+             (<a> href: "https://srfi-email.schemers.org/srfi-179" "archive")".")
         
         
-	(<ul> (<li> "Received: 2020-01-11")
+        (<ul> (<li> "Received: 2020-01-11")
               (<li> "60-day deadline: 2020-03-13")
               (<li> "Draft #1 published: 2020-01-11")
               (<li> "Draft #2 published: 2020-01-25")
@@ -70,14 +70,14 @@ MathJax.Hub.Config({
               (<li> "Draft #5 published: 2020-04-30")
               (<li> "Draft #6 published: 2020-05-03"))
 
-	(<h2> "Abstract")
-	(<p>
-	 "This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a "
-	 "mapping, or function, from multi-indices of exact integers $i_0,\\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices "
-	 "$i_0,\\ldots,i_{d-1}$ that are valid for a given array form the "(<i>'domain)" of the array.  In this SRFI, each array's domain consists "
-	 " of the cross product of nonempty intervals of exact integers $[l_0,u_0)\\times[l_1,u_1)\\times\\cdots\\times[l_{d-1},u_{d-1})$ of $\\mathbb Z^d$, $d$-tuples of "
-	 "integers.  Thus, we introduce a data type "
-	 "called $d$-"(<i> 'intervals)", or more briefly "(<i>'intervals)", that encapsulates this notion. (We borrow this terminology from, e.g., "
+        (<h2> "Abstract")
+        (<p>
+         "This SRFI specifies an array mechanism for Scheme. Arrays as defined here are quite general; at their most basic, an array is simply a "
+         "mapping, or function, from multi-indices of exact integers $i_0,\\ldots,i_{d-1}$ to Scheme values.  The set of multi-indices "
+         "$i_0,\\ldots,i_{d-1}$ that are valid for a given array form the "(<i>'domain)" of the array.  In this SRFI, each array's domain consists "
+         " of the cross product of nonempty intervals of exact integers $[l_0,u_0)\\times[l_1,u_1)\\times\\cdots\\times[l_{d-1},u_{d-1})$ of $\\mathbb Z^d$, $d$-tuples of "
+         "integers.  Thus, we introduce a data type "
+         "called $d$-"(<i> 'intervals)", or more briefly "(<i>'intervals)", that encapsulates this notion. (We borrow this terminology from, e.g., "
          " Elias Zakon's "(<a> href: "http://www.trillia.com/zakon1.html" "Basic Concepts of Mathematics")".) "
          "Specialized variants of arrays are specified to provide portable programs with efficient representations for common use cases.")
         (<h2> "Rationale")
@@ -115,72 +115,72 @@ MathJax.Hub.Config({
          (<li> "Some matrix examples have been added to this document."))
 
 
-	(<h2> "Overview")
-	(<h3> "Bawden-style arrays")
-	(<p>  "In a "(<a> href: "https://groups.google.com/forum/?hl=en#!msg/comp.lang.scheme/7nkx58Kv6RI/a5hdsduFL2wJ" "1993 post")
-	      " to the news group comp.lang.scheme, Alan Bawden gave a simple implementation of multi-dimensional arrays in R4RS scheme. "
-	      "The only constructor of new arrays required specifying an initial value, and he provided the three low-level primitives "
-	      (<code>'array-ref)", "(<code>'array-set!)", and "(<code>'array?)", as well as "(<code>'make-array)" and "(<code>'make-shared-array)
+        (<h2> "Overview")
+        (<h3> "Bawden-style arrays")
+        (<p>  "In a "(<a> href: "https://groups.google.com/forum/?hl=en#!msg/comp.lang.scheme/7nkx58Kv6RI/a5hdsduFL2wJ" "1993 post")
+              " to the news group comp.lang.scheme, Alan Bawden gave a simple implementation of multi-dimensional arrays in R4RS scheme. "
+              "The only constructor of new arrays required specifying an initial value, and he provided the three low-level primitives "
+              (<code>'array-ref)", "(<code>'array-set!)", and "(<code>'array?)", as well as "(<code>'make-array)" and "(<code>'make-shared-array)
               ".  His arrays were defined on rectangular intervals in "
-	      "$\\mathbb Z^d$ of the form $[l_0,u_0)\\times\\cdots\\times [l_{d-1},u_{d-1})$.  I'll note that his function "(<code>'array-set!)
-	      " put the value to be entered into the array at the front of the variable-length list of indices that indicate where to "
-	      "place the new value.  He offered an intriguing way to \"share\" arrays "
-	      "in the form of a routine "(<code>'make-shared-array)" that took a mapping from a new interval of indices into the domain "
-	      "of the array to be shared.  His implementation incorporated what he called an "(<i>'indexer)", which was a function from "
-	      "the interval $[l_0,u_0)\\times\\cdots\\times [l_{d-1},u_{d-1})$ to an interval $[0,N)$, where the "(<i>'body)" of the array consisted of "
-	      "a single Scheme vector of length $N$.  Bawden called the mapping specified in "(<code>'make-shared-array)" "
-	      (<i>'linear)", but I prefer the term "(<i>'affine)", as I explain later.")
-	(<p> "Mathematically, Bawden's arrays can be described as follows.  We'll use the vector notation $\\vec i$ for a multi-index "
-	     "$i_0,\\ldots,i_{d-1}$. (Multi-indices correspond to Scheme "(<code>'values)".)  Arrays will be denoted by capital letters "
-	     "$A,B,\\ldots$, the domain of the array $A$ will be denoted by $D_A$, "
-	     "and the indexer of $A$, mapping $D_A$ to the interval $[0,N)$ will be denoted by $I_A$.  Initially, Bawden constructs "
-	     "$I_A$ such that $I_A(\\vec i)$ steps consecutively through the values $0,1,\\ldots,N-1$ as $\\vec i$ steps through the "
-	     "multi-indices $(l_0,\\ldots,l_{d-2},l_{d-1})$, $(l_0,\\ldots,l_{d-2},l_{d-1}+1)$, $\\ldots$, $(l_0,\\ldots,l_{d-2}+1,l_{d-1})$, etc., in lexicographical order, which means "
-	     "that if $\\vec i$ and $\\vec j$ are two multi-indices, then $\\vec i<\\vec j$ iff the first coordinate $k$ where $\\vec i$ and $\\vec j$ "
-	     "differ satisfies $\\vec i_k<\\vec j_k$.")
-	(<p> "In "(<code>'make-shared-array)", Bawden allows you to specify a new $r$-dimensional interval $D_B$ as the domain of a new array $B$, and a "
-	     "mapping $T_{BA}:D_B\\to D_A$ of the form $T_{BA}(\\vec i)=M\\vec i+\\vec b$; here $M$ is a $d\\times r$ matrix of integer values and "
-	     "$\\vec b$ is a $d$-vector.  So this mapping $T_{BA}$ is "(<i>'affine)", in that $T_{BA}(\\vec i)-T_{BA}(\\vec j)=M(\\vec i-\\vec j)$ is "
-	     (<i>'linear)" (in a linear algebra sense) in $\\vec i-\\vec j$.  The new indexer of $B$ satisfies $I_B(\\vec i)=I_A(T_{BA}(\\vec i))$.")
-	(<p> "A fact Bawden exploits in the code, but doesn't point out in the short post, is that $I_B$ is again an affine map, and indeed, the composition "
-	     "of "(<i>'any)" two affine maps is again affine.")
-	(<h3> "Our extensions of Bawden-style arrays")
-	(<p> "We incorporate Bawden-style arrays into this SRFI, but extend them in one minor way that we find useful.")
-	(<p> "We introduce the notion of a "(<i>"storage class")", an object that contains functions that manipulate, store, check, etc., different types of values. "
-	     "A "(<code>'generic-storage-class)" can manipulate any Scheme value, "
-	     "whereas, e.g., a "(<code>'u1-storage-class)" can store only the values 0 and 1 in each element of a body.")
-	(<p> "We also require that our affine maps be one-to-one, so that if $\\vec i\\neq\\vec j$ then $T(\\vec i)\\neq T(\\vec j)$.  Without this property, modifying "
-	     "the $\\vec i$th component of $A$ would cause the $\\vec j$th component to change.")
-	(<h3> "Common transformations on Bawden-style arrays")
-	(<p> "Requiring the transformations $T_{BA}:D_B\\to D_A$ to be affine may seem  esoteric and restricting, but in fact many common and useful array transformations "
-	     "can be expressed in this way.  We give several examples below: ")
-	(<ul>
-	 (<li> (<b> "Restricting the domain of an array: ")
-	       "  If the domain of $B$, $D_B$, is a subset of the domain of $A$, then $T_{BA}(\\vec i)=\\vec i$ is a one-to-one affine mapping.  We define "
-	       (<code>'array-extract)" to define this common operation; it's like looking at a rectangular sub-part of a spreadsheet. We use it to extract the common part of overlapping domains of three arrays in an image processing example below. ")
+              "$\\mathbb Z^d$ of the form $[l_0,u_0)\\times\\cdots\\times [l_{d-1},u_{d-1})$.  I'll note that his function "(<code>'array-set!)
+              " put the value to be entered into the array at the front of the variable-length list of indices that indicate where to "
+              "place the new value.  He offered an intriguing way to \"share\" arrays "
+              "in the form of a routine "(<code>'make-shared-array)" that took a mapping from a new interval of indices into the domain "
+              "of the array to be shared.  His implementation incorporated what he called an "(<i>'indexer)", which was a function from "
+              "the interval $[l_0,u_0)\\times\\cdots\\times [l_{d-1},u_{d-1})$ to an interval $[0,N)$, where the "(<i>'body)" of the array consisted of "
+              "a single Scheme vector of length $N$.  Bawden called the mapping specified in "(<code>'make-shared-array)" "
+              (<i>'linear)", but I prefer the term "(<i>'affine)", as I explain later.")
+        (<p> "Mathematically, Bawden's arrays can be described as follows.  We'll use the vector notation $\\vec i$ for a multi-index "
+             "$i_0,\\ldots,i_{d-1}$. (Multi-indices correspond to Scheme "(<code>'values)".)  Arrays will be denoted by capital letters "
+             "$A,B,\\ldots$, the domain of the array $A$ will be denoted by $D_A$, "
+             "and the indexer of $A$, mapping $D_A$ to the interval $[0,N)$ will be denoted by $I_A$.  Initially, Bawden constructs "
+             "$I_A$ such that $I_A(\\vec i)$ steps consecutively through the values $0,1,\\ldots,N-1$ as $\\vec i$ steps through the "
+             "multi-indices $(l_0,\\ldots,l_{d-2},l_{d-1})$, $(l_0,\\ldots,l_{d-2},l_{d-1}+1)$, $\\ldots$, $(l_0,\\ldots,l_{d-2}+1,l_{d-1})$, etc., in lexicographical order, which means "
+             "that if $\\vec i$ and $\\vec j$ are two multi-indices, then $\\vec i<\\vec j$ iff the first coordinate $k$ where $\\vec i$ and $\\vec j$ "
+             "differ satisfies $\\vec i_k<\\vec j_k$.")
+        (<p> "In "(<code>'make-shared-array)", Bawden allows you to specify a new $r$-dimensional interval $D_B$ as the domain of a new array $B$, and a "
+             "mapping $T_{BA}:D_B\\to D_A$ of the form $T_{BA}(\\vec i)=M\\vec i+\\vec b$; here $M$ is a $d\\times r$ matrix of integer values and "
+             "$\\vec b$ is a $d$-vector.  So this mapping $T_{BA}$ is "(<i>'affine)", in that $T_{BA}(\\vec i)-T_{BA}(\\vec j)=M(\\vec i-\\vec j)$ is "
+             (<i>'linear)" (in a linear algebra sense) in $\\vec i-\\vec j$.  The new indexer of $B$ satisfies $I_B(\\vec i)=I_A(T_{BA}(\\vec i))$.")
+        (<p> "A fact Bawden exploits in the code, but doesn't point out in the short post, is that $I_B$ is again an affine map, and indeed, the composition "
+             "of "(<i>'any)" two affine maps is again affine.")
+        (<h3> "Our extensions of Bawden-style arrays")
+        (<p> "We incorporate Bawden-style arrays into this SRFI, but extend them in one minor way that we find useful.")
+        (<p> "We introduce the notion of a "(<i>"storage class")", an object that contains functions that manipulate, store, check, etc., different types of values. "
+             "A "(<code>'generic-storage-class)" can manipulate any Scheme value, "
+             "whereas, e.g., a "(<code>'u1-storage-class)" can store only the values 0 and 1 in each element of a body.")
+        (<p> "We also require that our affine maps be one-to-one, so that if $\\vec i\\neq\\vec j$ then $T(\\vec i)\\neq T(\\vec j)$.  Without this property, modifying "
+             "the $\\vec i$th component of $A$ would cause the $\\vec j$th component to change.")
+        (<h3> "Common transformations on Bawden-style arrays")
+        (<p> "Requiring the transformations $T_{BA}:D_B\\to D_A$ to be affine may seem  esoteric and restricting, but in fact many common and useful array transformations "
+             "can be expressed in this way.  We give several examples below: ")
+        (<ul>
+         (<li> (<b> "Restricting the domain of an array: ")
+               "  If the domain of $B$, $D_B$, is a subset of the domain of $A$, then $T_{BA}(\\vec i)=\\vec i$ is a one-to-one affine mapping.  We define "
+               (<code>'array-extract)" to define this common operation; it's like looking at a rectangular sub-part of a spreadsheet. We use it to extract the common part of overlapping domains of three arrays in an image processing example below. ")
          (<li> (<b> "Tiling an array: ")
                "For various reasons (parallel processing, optimizing cache localization, GPU programming, etc.) one may wish to process a large array as a number of subarrays of the same dimensions, which we call "(<i>'tiling)" the array.  The routine "(<code>'array-tile)" returns a new array, each entry of which is a subarray extracted (in the sense of "(<code>'array-extract)") from the input array.")
-	 (<li> (<b> "Translating the domain of an array: ")
-	       "If $\\vec d$ is a vector of integers, then $T_{BA}(\\vec i)=\\vec i-\\vec d$ is a one-to-one affine map of $D_B=\\{\\vec i+\\vec d\\mid \\vec i\\in D_A\\}$ onto $D_A$. "
-	       "We call $D_B$ the "(<i>'translate)" of $D_A$, and we define "(<code>'array-translate)" to provide this operation.")
-	 (<li> (<b> "Permuting the coordinates of an array: ")
-	       "If $\\pi$ "(<a> href: "https://en.wikipedia.org/wiki/Permutation" 'permutes)" the coordinates of a multi-index $\\vec i$, and $\\pi^{-1}$ is the inverse of $\\pi$, then "
-	       "$T_{BA}(\\vec i)=\\pi (\\vec i)$ is a one-to-one affine map from $D_B=\\{\\pi^{-1}(\\vec i)\\mid \\vec i\\in D_A\\}$ onto $D_A$.  We provide "(<code>'array-permute)" for this operation. "
-	       "(The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) "
+         (<li> (<b> "Translating the domain of an array: ")
+               "If $\\vec d$ is a vector of integers, then $T_{BA}(\\vec i)=\\vec i-\\vec d$ is a one-to-one affine map of $D_B=\\{\\vec i+\\vec d\\mid \\vec i\\in D_A\\}$ onto $D_A$. "
+               "We call $D_B$ the "(<i>'translate)" of $D_A$, and we define "(<code>'array-translate)" to provide this operation.")
+         (<li> (<b> "Permuting the coordinates of an array: ")
+               "If $\\pi$ "(<a> href: "https://en.wikipedia.org/wiki/Permutation" 'permutes)" the coordinates of a multi-index $\\vec i$, and $\\pi^{-1}$ is the inverse of $\\pi$, then "
+               "$T_{BA}(\\vec i)=\\pi (\\vec i)$ is a one-to-one affine map from $D_B=\\{\\pi^{-1}(\\vec i)\\mid \\vec i\\in D_A\\}$ onto $D_A$.  We provide "(<code>'array-permute)" for this operation. "
+               "(The only nonidentity permutation of a two-dimensional spreadsheet turns rows into columns and vice versa.) "
                "We also provide "(<code>'array-rotate)" for the special permutations that rotate the axes. For example, in three dimensions we have the following three rotations: $i\\ j\\ k\\to j\\ k\\ i$; $i\\ j\\ k\\to k\\ i\\ j$; and the trivial (identity) rotation $i\\ j\\ k\\to i\\ j\\ k$.")
-	 (<li> (<b> "Currying an array: ")
-	       "Let's denote the cross product of two intervals $\\text{Int}_1$ and $\\text{Int}_2$ by $\\text{Int}_1\\times\\text{Int}_2$; "
-	       "if $\\vec j=(j_0,\\ldots,j_{r-1})\\in \\text{Int}_1$ and $\\vec i=(i_0,\\ldots,i_{s-1})\\in \\text{Int}_2$, then "
-	       "$\\vec j\\times\\vec i$, which we define to be $(j_0,\\ldots,j_{r-1},i_0,\\ldots,i_{s-1})$, is in $\\text{Int}_1\\times\\text{Int}_2$. "
-	       "If $D_A=\\text{Int}_1\\times\\text{Int}_2$ and $\\vec j\\in\\text{Int}_1$, then $T_{BA}(\\vec i)=\\vec j\\times\\vec i$ "
-	       "is a one-to-one affine mapping from $D_B=\\text{Int}_2$ into $D_A$.  For each vector $\\vec j$ we can compute a new array in this way; we provide "
-	       (<code>'array-curry)" for this operation, which returns an array whose domain is $\\text{Int}_1$ and whose elements are themselves arrays, each of which is defined on $\\text{Int}_2$. "
-	       "Currying a two-dimensional array would be like organizing a spreadsheet into a one-dimensional array of rows of the spreadsheet.")
-	 (<li> (<b> "Traversing some indices in a multi-index in reverse order: ")
-	       "Consider an array $A$ with domain $D_A=[l_0,u_0)\\times\\cdots\\times[l_{d-1},u_{d-1})$. Fix $D_B=D_A$ and assume we're given a vector of booleans $F$ ($F$ for \"flip?\"). "
+         (<li> (<b> "Currying an array: ")
+               "Let's denote the cross product of two intervals $\\text{Int}_1$ and $\\text{Int}_2$ by $\\text{Int}_1\\times\\text{Int}_2$; "
+               "if $\\vec j=(j_0,\\ldots,j_{r-1})\\in \\text{Int}_1$ and $\\vec i=(i_0,\\ldots,i_{s-1})\\in \\text{Int}_2$, then "
+               "$\\vec j\\times\\vec i$, which we define to be $(j_0,\\ldots,j_{r-1},i_0,\\ldots,i_{s-1})$, is in $\\text{Int}_1\\times\\text{Int}_2$. "
+               "If $D_A=\\text{Int}_1\\times\\text{Int}_2$ and $\\vec j\\in\\text{Int}_1$, then $T_{BA}(\\vec i)=\\vec j\\times\\vec i$ "
+               "is a one-to-one affine mapping from $D_B=\\text{Int}_2$ into $D_A$.  For each vector $\\vec j$ we can compute a new array in this way; we provide "
+               (<code>'array-curry)" for this operation, which returns an array whose domain is $\\text{Int}_1$ and whose elements are themselves arrays, each of which is defined on $\\text{Int}_2$. "
+               "Currying a two-dimensional array would be like organizing a spreadsheet into a one-dimensional array of rows of the spreadsheet.")
+         (<li> (<b> "Traversing some indices in a multi-index in reverse order: ")
+               "Consider an array $A$ with domain $D_A=[l_0,u_0)\\times\\cdots\\times[l_{d-1},u_{d-1})$. Fix $D_B=D_A$ and assume we're given a vector of booleans $F$ ($F$ for \"flip?\"). "
                "Then define $T_{BA}:D_B\\to D_A$ by $i_j\\to i_j$ if $F_j$ is "(<code>'#f)" and $i_j\\to u_j+l_j-1-i_j$ if  $F_j$ is "(<code>'#t)". "
-	       "In other words,  we reverse the ordering of the $j$th coordinate of $\\vec i$ if and only if $F_j$ is true. "
-	       "$T_{BA}$ is an affine mapping from $D_B\\to D_A$, which defines a new array $B$, and we can provide "(<code>'array-reverse)" for this operation. "
+               "In other words,  we reverse the ordering of the $j$th coordinate of $\\vec i$ if and only if $F_j$ is true. "
+               "$T_{BA}$ is an affine mapping from $D_B\\to D_A$, which defines a new array $B$, and we can provide "(<code>'array-reverse)" for this operation. "
                "Applying "(<code>'array-reverse)" to a two-dimensional spreadsheet might reverse the order of the rows or columns (or both).")
          (<li> (<b> "Uniformly sampling an array: ")
                "Assume that $A$ is an array with domain $[0,u_1)\\times\\cdots\\times[0,u_{d-1})$ (i.e., an interval all of whose lower bounds are zero). "
@@ -189,42 +189,42 @@ MathJax.Hub.Config({
                "$T_{BA}(\\vec i)_j=i_j\\times S_j$, i.e., the $j$th coordinate is scaled by $S_j$.  ($D_B$ contains precisely those multi-indices that $T_{BA}$ maps into $D_A$.) "
                "Then $T_{BA}$ is an affine one-to-one mapping, and we provide "(<code>'interval-scale)" and "(<code>'array-sample)" for these operations.")
          )
-	(<p> "We make several remarks.  First, all these operations could have been computed by specifying the particular mapping $T_{BA}$ explicitly, so that these routines are simply "
-	     "\"convenience\" procedures.  Second, because the composition of any number of affine mappings are again affine, accessing or changing the elements of a "
-	     "restricted, translated, curried, permuted array is no slower than accessing or changing the elements of the original array itself. "
-	     "Finally, we note that by combining array currying and permuting, say, one can come up with simple expressions of powerful algorithms, such as extending "
-	     "one-dimensional transforms to multi-dimensional separable transforms, or quickly generating two-dimensional slices of three-dimensional image data. "
-	     "Examples are given below.")
+        (<p> "We make several remarks.  First, all these operations could have been computed by specifying the particular mapping $T_{BA}$ explicitly, so that these routines are simply "
+             "\"convenience\" procedures.  Second, because the composition of any number of affine mappings are again affine, accessing or changing the elements of a "
+             "restricted, translated, curried, permuted array is no slower than accessing or changing the elements of the original array itself. "
+             "Finally, we note that by combining array currying and permuting, say, one can come up with simple expressions of powerful algorithms, such as extending "
+             "one-dimensional transforms to multi-dimensional separable transforms, or quickly generating two-dimensional slices of three-dimensional image data. "
+             "Examples are given below.")
 
-	(<h3> "Generalized arrays")
-	(<p> "Bawden-style arrays are clearly useful as a programming construct, but they do not fulfill all our needs in this area. "
-	     "An array, as commonly understood, provides a mapping from multi-indices  $(i_0,\\ldots,i_{d-1})$ of exact integers
+        (<h3> "Generalized arrays")
+        (<p> "Bawden-style arrays are clearly useful as a programming construct, but they do not fulfill all our needs in this area. "
+             "An array, as commonly understood, provides a mapping from multi-indices  $(i_0,\\ldots,i_{d-1})$ of exact integers
 in a nonempty, rectangular, $d$-dimensional interval $[l_0,u_0)\\times[l_1,u_1)\\times\\cdots\\times[l_{d-1},u_{d-1})$ (the "(<i>'domain)" of the array) to Scheme objects.
 Thus, two things are necessary to specify an array: an interval and a mapping that has that interval as its domain.")
-	(<p> "Since these two things are often sufficient for certain algorithms, we introduce in this SRFI a minimal set of interfaces for dealing with such arrays.")
-	(<p> "Specifically, an array specifies a nonempty, multi-dimensional interval, called its "(<i> "domain")", and a mapping from this domain to Scheme objects.  This mapping is called the "(<i> 'getter)" of the array, accessed with the procedure "(<code>'array-getter)"; the domain of the array (more precisely, the domain of the array's getter) is accessed with the procedure "(<code>'array-domain)".")
-	(<p> "If this mapping can be changed, the array is said to be "(<i> 'mutable)" and the mutation is effected
+        (<p> "Since these two things are often sufficient for certain algorithms, we introduce in this SRFI a minimal set of interfaces for dealing with such arrays.")
+        (<p> "Specifically, an array specifies a nonempty, multi-dimensional interval, called its "(<i> "domain")", and a mapping from this domain to Scheme objects.  This mapping is called the "(<i> 'getter)" of the array, accessed with the procedure "(<code>'array-getter)"; the domain of the array (more precisely, the domain of the array's getter) is accessed with the procedure "(<code>'array-domain)".")
+        (<p> "If this mapping can be changed, the array is said to be "(<i> 'mutable)" and the mutation is effected
 by the array's "(<i> 'setter)", accessed by the procedure "(<code>'array-setter)".  We call an object of this type a mutable array. Note: If an array does not have a setter, then we call it immutable even though the array's getter might not be a \"pure\" function, i.e., the value it returns may not depend solely on the arguments passed to the getter.")
-	(<p> "In general, we leave the implementation of generalized arrays completely open.  They may be defined simply by closures, or
+        (<p> "In general, we leave the implementation of generalized arrays completely open.  They may be defined simply by closures, or
 they may have hash tables or databases behind an implementation, one may read the values from a file, etc.")
-	(<p> "In this SRFI, Bawden-style arrays are called "(<i> 'specialized)". A specialized array is an example of a mutable array.")
+        (<p> "In this SRFI, Bawden-style arrays are called "(<i> 'specialized)". A specialized array is an example of a mutable array.")
 
-	(<h3> "Sharing generalized arrays")
-	(<p> "Even if an array $A$ is not a specialized array, then it could be \"shared\" by specifying a new interval $D_B$ as the domain of "
-	     "a new array $B$ and an affine map $T_{BA}:D_B\\to D_A$.  Each call to $B$ would then be computed as $B(\\vec i)=A(T_{BA}(\\vec i))$.")
-	(<p> "One could again \"share\" $B$, given a new interval $D_C$ as the domain of a new array $C$ and an affine transform $T_{CB}:D_C\\to D_B$, and then each access $C(\\vec i)=A(T_{BA}(T_{CB}(\\vec i)))$.  The composition $T_{BA}\\circ T_{CB}:D_C\\to D_A$, being itself affine, could be precomputed and stored as $T_{CA}:D_C\\to D_A$, and $C(\\vec i)=A(T_{CA}(\\vec i))$ can be computed with the overhead of computing a single affine transformation.")
-	(<p> "So, if we wanted, we could share generalized arrays with constant overhead by adding a single layer of (multi-valued) affine transformations on top of evaluating generalized arrays.  Even though this could be done transparently to the user, we do not do that here; it would be a compatible extension of this SRFI to do so.  We provide only the routine "(<code>'specialized-array-share)", not a more general "(<code>'array-share)".")
-	(<p> "Certain ways of sharing generalized arrays, however, are relatively easy to code and not that expensive.  If we denote "(<code>"(array-getter A)")" by "(<code>'A-getter)", then if B is the result of "(<code>'array-extract)" applied to A, then "
-	     (<code>"(array-getter B)")" is simply "(<code>'A-getter)".  Similarly, if A is a two-dimensional array, and B is derived from A by applying the permutation $\\pi((i,j))=(j,i)$, then "(<code>"(array-getter B)")" is "
-	     (<code>"(lambda (i j) (A-getter j i))")".  Translation and currying also lead to transformed arrays whose getters are relatively efficiently derived from "(<code>'A-getter)", at least for arrays of small dimension.")
-	(<p> "Thus, while we do not provide for sharing of generalized arrays for general one-to-one affine maps $T$, we do allow it for the specific functions "(<code>'array-extract)", "(<code>'array-translate)", "(<code>'array-permute)",  "
-	     (<code>'array-curry)",  "(<code>'array-reverse)", "(<code>'array-tile)", "(<code>'array-rotate)" and "(<code>'array-sample)",  and we provide relatively efficient implementations of these functions for arrays of dimension no greater than four.")
-	(<h3> "Array-map does not produce a specialized array")
-	(<p> "Daniel Friedman and David Wise wrote a famous paper "(<a> href: "http://www.cs.indiana.edu/cgi-bin/techreports/TRNNN.cgi?trnum=TR44" "CONS should not Evaluate its Arguments")". "
-	     "In the spirit of that paper, our procedure "(<code>'array-map)" does not immediately produce a specialized array, but a simple immutable array, whose elements are recomputed from the arguments of "(<code>'array-map)
-	     " each time they are accessed.   This immutable array can be passed on to further applications of "(<code>'array-map)" for further processing, without generating the storage bodies for intermediate arrays.")
-	(<p> "We provide the procedure "(<code>'array->specialized-array)" to transform a generalized array (like that returned by "(<code>'array-map)
-	     ") to a specialized, Bawden-style array, for which accessing each element again takes $O(1)$ operations.")
+        (<h3> "Sharing generalized arrays")
+        (<p> "Even if an array $A$ is not a specialized array, then it could be \"shared\" by specifying a new interval $D_B$ as the domain of "
+             "a new array $B$ and an affine map $T_{BA}:D_B\\to D_A$.  Each call to $B$ would then be computed as $B(\\vec i)=A(T_{BA}(\\vec i))$.")
+        (<p> "One could again \"share\" $B$, given a new interval $D_C$ as the domain of a new array $C$ and an affine transform $T_{CB}:D_C\\to D_B$, and then each access $C(\\vec i)=A(T_{BA}(T_{CB}(\\vec i)))$.  The composition $T_{BA}\\circ T_{CB}:D_C\\to D_A$, being itself affine, could be precomputed and stored as $T_{CA}:D_C\\to D_A$, and $C(\\vec i)=A(T_{CA}(\\vec i))$ can be computed with the overhead of computing a single affine transformation.")
+        (<p> "So, if we wanted, we could share generalized arrays with constant overhead by adding a single layer of (multi-valued) affine transformations on top of evaluating generalized arrays.  Even though this could be done transparently to the user, we do not do that here; it would be a compatible extension of this SRFI to do so.  We provide only the routine "(<code>'specialized-array-share)", not a more general "(<code>'array-share)".")
+        (<p> "Certain ways of sharing generalized arrays, however, are relatively easy to code and not that expensive.  If we denote "(<code>"(array-getter A)")" by "(<code>'A-getter)", then if B is the result of "(<code>'array-extract)" applied to A, then "
+             (<code>"(array-getter B)")" is simply "(<code>'A-getter)".  Similarly, if A is a two-dimensional array, and B is derived from A by applying the permutation $\\pi((i,j))=(j,i)$, then "(<code>"(array-getter B)")" is "
+             (<code>"(lambda (i j) (A-getter j i))")".  Translation and currying also lead to transformed arrays whose getters are relatively efficiently derived from "(<code>'A-getter)", at least for arrays of small dimension.")
+        (<p> "Thus, while we do not provide for sharing of generalized arrays for general one-to-one affine maps $T$, we do allow it for the specific functions "(<code>'array-extract)", "(<code>'array-translate)", "(<code>'array-permute)",  "
+             (<code>'array-curry)",  "(<code>'array-reverse)", "(<code>'array-tile)", "(<code>'array-rotate)" and "(<code>'array-sample)",  and we provide relatively efficient implementations of these functions for arrays of dimension no greater than four.")
+        (<h3> "Array-map does not produce a specialized array")
+        (<p> "Daniel Friedman and David Wise wrote a famous paper "(<a> href: "http://www.cs.indiana.edu/cgi-bin/techreports/TRNNN.cgi?trnum=TR44" "CONS should not Evaluate its Arguments")". "
+             "In the spirit of that paper, our procedure "(<code>'array-map)" does not immediately produce a specialized array, but a simple immutable array, whose elements are recomputed from the arguments of "(<code>'array-map)
+             " each time they are accessed.   This immutable array can be passed on to further applications of "(<code>'array-map)" for further processing, without generating the storage bodies for intermediate arrays.")
+        (<p> "We provide the procedure "(<code>'array->specialized-array)" to transform a generalized array (like that returned by "(<code>'array-map)
+             ") to a specialized, Bawden-style array, for which accessing each element again takes $O(1)$ operations.")
 
         (<h3> "Notational convention")
         (<p> "If "(<code>(<var>'A))" is an array, then we generally define "(<code>(<var>'A_))" to be "(<code>"(array-getter "(<var>'A)")")" and  "(<code>(<var>'A!))" to be "(<code>"(array-setter "(<var>'A)")")".  The latter notation is motivated by the general Scheme convention that the names of functions that modify the contents of data structures end in "(<code>(<var>"!"))", while the notation for the getter of an array is motivated by the TeX notation for subscripts.  See particularly the "(<a> href: "#Haar" "Haar transform")" example.")
@@ -1702,24 +1702,24 @@ order in array->specialized-array guarantees the the correct order of execution 
     (lambda (port)
       (let* ((greys
               (pgm-greys pgm-data))
-	     (pgm-array
+             (pgm-array
               (pgm-pixels pgm-data))
-	     (domain
+             (domain
               (array-domain pgm-array))
-	     (rows
+             (rows
               (fx- (interval-upper-bound domain 0)
                    (interval-lower-bound domain 0)))
-	     (columns
+             (columns
               (fx- (interval-upper-bound domain 1)
                    (interval-lower-bound domain 1))))
-	(if force-ascii
-	    (display \"P2\" port)
-	    (display \"P5\" port))
-	(newline port)
-	(display columns port) (display " " port)
-	(display rows port) (newline port)
-	(display greys port) (newline port)
-	(array-for-each
+        (if force-ascii
+            (display \"P2\" port)
+            (display \"P5\" port))
+        (newline port)
+        (display columns port) (display " " port)
+        (display rows port) (newline port)
+        (display greys port) (newline port)
+        (array-for-each
          (if force-ascii
              (let ((next-pixel-in-line 1))
                (lambda (p)
@@ -1908,9 +1908,9 @@ $d,2 d,3 d,\\ldots$, defined only on the domains where this makes sense: ")
 
 (define (expose difference-images)
   (pretty-print (map (lambda (difference-image)
-		       (list (array-domain difference-image)
-			     (array->list difference-image)))
-		     difference-images)))
+                       (list (array-domain difference-image)
+                             (array->list difference-image)))
+                     difference-images)))
 
 (begin
   (display
@@ -2000,16 +2000,16 @@ Second-differences in the direction $k\\times (1,-1)$:
 (<pre>(<code>"
 (define (1D-Haar-loop a)
   (let ((a_ (array-getter a))
-	(a! (array-setter a))
-	(n (interval-upper-bound (array-domain a) 0)))
+        (a! (array-setter a))
+        (n (interval-upper-bound (array-domain a) 0)))
     (do ((i 0 (fx+ i 2)))
-	((fx= i n))
+        ((fx= i n))
       (let* ((a_i               (a_ i))
-	     (a_i+1             (a_ (fx+ i 1)))
-	     (scaled-sum        (fl/ (fl+ a_i a_i+1) (flsqrt 2.0)))
-	     (scaled-difference (fl/ (fl- a_i a_i+1) (flsqrt 2.0))))
-	(a! scaled-sum i)
-	(a! scaled-difference (fx+ i 1))))))
+             (a_i+1             (a_ (fx+ i 1)))
+             (scaled-sum        (fl/ (fl+ a_i a_i+1) (flsqrt 2.0)))
+             (scaled-difference (fl/ (fl- a_i a_i+1) (flsqrt 2.0))))
+        (a! scaled-sum i)
+        (a! scaled-difference (fx+ i 1))))))
 
 (define 1D-Haar-transform
   (recursively-apply-transform-and-downsample 1D-Haar-loop))
@@ -2044,15 +2044,15 @@ Second-differences in the direction $k\\times (1,-1)$:
                         (else 0.)))))))
   (display \"\nInitial image:\n\")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (hyperbolic-Haar-transform image)
   (display \"\\nArray of hyperbolic Haar wavelet coefficients: \\n\")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (hyperbolic-Haar-inverse-transform image)
   (display \"\\nReconstructed image: \\n\")
   (pretty-print (list (array-domain image)
-		      (array->list image))))
+                      (array->list image))))
 "))
 (<p> "This yields: ")
 (<pre>"
@@ -2097,15 +2097,15 @@ Reconstructed image:
                         (else 0.)))))))
   (display \"\\nInitial image:\\n\")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (Haar-transform image)
   (display \"\\nArray of Haar wavelet coefficients: \\n\")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (Haar-inverse-transform image)
   (display \"\\nReconstructed image: \\n\")
   (pretty-print (list (array-domain image)
-		      (array->list image))))
+                      (array->list image))))
 ")
 (<p> "This yields: ")
 (<pre>"

--- a/srfi-179.scm
+++ b/srfi-179.scm
@@ -100,9 +100,8 @@ MathJax.Hub.Config({
                (<code>'array-outer-product)", "
                (<code>'array-tile)", "
                (<code>'array-rotate)", "
-               (<code>'array-reduce)", "
-               (<code>'array-assign!)", "
-               (<code>'array-swap!)
+               (<code>'array-reduce)", and "
+               (<code>'array-assign!)" "
                " have been added together with some examples.")
          (<li> "Global variables "
                (<code>'f8-storage-class)" and "
@@ -347,7 +346,6 @@ they may have hash tables or databases behind an implementation, one may read th
                  (<a> href: "#array->list" "array->list") END
                  (<a> href: "#list->specialized-array" "list->specialized-array") END
                  (<a> href: "#array-assign!" "array-assign!") END
-                 (<a> href: "#array-swap!" "array-swap!") END
                  (<a> href: "#array-ref" "array-ref") END
                  (<a> href: "#array-set!" "array-set!") END
                  "."
@@ -1518,13 +1516,6 @@ We attempt to compute this in floating-point arithmetic in two ways. In the firs
      "and associates each value to the same multi-index in "(<code>(<var>'destination))".")
 (<p> "It is an error if the arguments don't satisfy these assumptions.")
 (<p> "If assigning any element of "(<code>(<var>'destination))" affects the value of any element of "(<code>(<var>'source))", then the result is undefined.")
-
-(format-lambda-list '(array-swap! A B))
-(<p> "Assumes that "(<code>(<var>'A))" and "(<code>(<var>'B))" are mutable arrays with the same domain, and that the elements of each of them can get stored in the other.")
-(<p> "Evaluates "(<code>"(array-getter "(<var>'A)")")" on the multi-indices in "(<code>"(array-domain "(<var>'A)")")" in an unspecified order, "
-     "and associates each value to the same multi-index in "(<code>(<var>'B))"; similarly it assigns the values of "(<code>"(array-getter "(<var>'B)")")" applied to the  multi-indices of "(<code>"(array-domain "(<var>'B)")")" to the associated indices in "(<code>(<var>'A))".")
-(<p> "It is an error if the arguments don't satisfy these assumptions.")
-(<p> "If assigning any element of "(<code>(<var>'A))" affects the value of any element of "(<code>(<var>'B))", or vice versa, then the result is undefined.")
 
 (format-lambda-list '(array-ref A i0 #\. i-tail))
 (<p> "Assumes that "(<code>(<var>'A))" is an array, and every element of "(<code>"(cons "(<var> "i0 i-tail")")")" is an exact integer.")

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -2700,66 +2700,6 @@
                                       (apply (array-getter mutable-array) multi-index)))))
           #t)))
 
-(pp "array-swap! tests")
-
-(test (array-swap! 'a 'a)
-      "array-swap!: The first argument is not a mutable array: ")
-
-(test (array-swap! (make-array (make-interval '#(0 0) '#(1 1)) values) 'a)
-      "array-swap!: The first argument is not a mutable array: ")
-
-(test (array-swap! (array->specialized-array (make-array (make-interval '#(0 0) '#(1 1)) values)) 'a)
-      "array-swap!: The second argument is not a mutable array: ")
-
-(test (array-swap! (array->specialized-array (make-array (make-interval '#(0 0) '#(1 1)) values))
-                   (make-array (make-interval '#(0 0) '#(1 1)) values))
-      "array-swap!: The second argument is not a mutable array: ")
-
-(test (array-swap! (array->specialized-array (make-array (make-interval '#(0 0) '#(1 1)) values))
-                   (array->specialized-array (make-array (make-interval '#(0 0) '#(2 1)) values)))
-      "array-swap!: The arguments do not have the same domain: ")
-
-(do ((i 0 (fx+ i 1)))
-    ((fx= i tests))
-  (let* ((interval
-          (random-interval 1 6))
-         (subinterval
-          (random-subinterval interval))
-         (specialized-array  ;; multi-index in order
-          (array->specialized-array (make-array interval list)))
-         (mutable-array      ;; multi-index in reversed ordr
-          (let ((specialized-array
-                 (array->specialized-array
-                  (make-array interval (lambda args (reverse args))))))
-            (make-array interval
-                        (array-getter specialized-array)
-                        (array-setter specialized-array))))
-         (specialized-subarray
-          (array-extract specialized-array subinterval))
-         (mutable-subarray
-          (array-extract mutable-array subinterval)))
-    (if (zero? (random 0 2))
-        (array-swap! specialized-subarray mutable-subarray)
-        (array-swap! mutable-subarray specialized-subarray))
-    (test (myarray= specialized-array
-                    ;; list of args, reversed in subarray
-                    (make-array interval
-                                (lambda multi-index
-                                  (if (apply interval-contains-multi-index? subinterval multi-index)
-                                      (reverse multi-index)
-                                      multi-index))))
-          #t)
-    (test (myarray= mutable-array
-                    ;; list of reversed args, except in subarray
-                    (make-array interval
-                                (lambda multi-index
-                                  (if (apply interval-contains-multi-index? subinterval multi-index)
-                                      multi-index
-                                      (reverse multi-index)))))
-          #t)))
-
-
-
 (pp "Miscellaneous error tests")
 
 (test (make-array (make-interval '#(0 0) '#(10 10))

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -6,31 +6,31 @@
 
 (define-macro (test expr value)
   `(let* (;(ignore (pretty-print ',expr))
-	  (result (call-with-current-continuation
-		   (lambda (c)
-		     (with-exception-catcher
-		      (lambda (args)
-			(cond ((error-exception? args)
-			       (c (error-exception-message args)))
-			      ;; I don't expect any of these, but it sure makes debugging easier
-			      ((unbound-global-exception? args)
-			       (unbound-global-exception-variable args))
+          (result (call-with-current-continuation
+                   (lambda (c)
+                     (with-exception-catcher
+                      (lambda (args)
+                        (cond ((error-exception? args)
+                               (c (error-exception-message args)))
+                              ;; I don't expect any of these, but it sure makes debugging easier
+                              ((unbound-global-exception? args)
+                               (unbound-global-exception-variable args))
                               ((wrong-number-of-arguments-exception? args)
                                "Wrong number of arguments passed to procedure ")
-			      (else
-			       "piffle")))
+                              (else
+                               "piffle")))
 
-		      (lambda ()
-			,expr))))))
+                      (lambda ()
+                        ,expr))))))
      (if (not (equal? result ,value))
-	 (pp (list ',expr" => " result ", not " ,value)))))
+         (pp (list ',expr" => " result ", not " ,value)))))
 
 (define-macro (test-multiple-values expr vals)
   `(call-with-values
        (lambda () ,expr)
      (lambda args
        (if (not (equal? args ,vals))
-	   (pp (list ',expr  " => " args ", not " ,vals #\newline))))))
+           (pp (list ',expr  " => " args ", not " ,vals #\newline))))))
 
 (define-macro (do-times  var n . body)
   ;; not so useful when the debugger can't report line numbers inside macros.
@@ -54,21 +54,21 @@
   (let ((result (make-vector n)))
     ;; fill it
     (do ((i 0 (fx+ i 1)))
-	((fx= i n))
+        ((fx= i n))
       (vector-set! result i i))
     ;; permute it
     (do ((i 0 (fx+ i 1)))
-	((fx= i n) result)
+        ((fx= i n) result)
       (let* ((index (random i n))
-	     (temp (vector-ref result index)))
-	(vector-set! result index (vector-ref result i))
-	(vector-set! result i temp)))))
+             (temp (vector-ref result index)))
+        (vector-set! result index (vector-ref result i))
+        (vector-set! result i temp)))))
 
 (define (vector-permute v permutation)
   (let* ((n (vector-length v))
-	 (result (make-vector n)))
+         (result (make-vector n)))
     (do ((i 0 (+ i 1)))
-	((= i n) result)
+        ((= i n) result)
       (vector-set! result i (vector-ref v (vector-ref permutation i))))))
 
 (define (filter p l)
@@ -215,18 +215,18 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 1 11)))))
-	 (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
+         (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
     (let ((interval (make-interval (list->vector lower)
-				   (list->vector upper)))
-	  (offset (random (length lower))))
+                                   (list->vector upper)))
+          (offset (random (length lower))))
       (test (interval-lower-bound interval offset)
-	    (list-ref lower offset))
+            (list-ref lower offset))
       (test (interval-upper-bound interval offset)
-	    (list-ref upper offset))
+            (list-ref upper offset))
       (test (interval-lower-bounds->list interval)
-	    lower)
+            lower)
       (test (interval-upper-bounds->list interval)
-	    upper))))
+            upper))))
 
 (pp "interval-lower-bounds->vector error tests")
 
@@ -243,18 +243,18 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 1 11)))))
-	 (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
+         (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
     (let ((interval (make-interval (list->vector lower)
-				   (list->vector upper)))
-	  (offset (random (length lower))))
+                                   (list->vector upper)))
+          (offset (random (length lower))))
       (test (interval-lower-bound interval offset)
-	    (list-ref lower offset))
+            (list-ref lower offset))
       (test (interval-upper-bound interval offset)
-	    (list-ref upper offset))
+            (list-ref upper offset))
       (test (interval-lower-bounds->vector interval)
-	    (list->vector lower))
+            (list->vector lower))
       (test (interval-upper-bounds->vector interval)
-	    (list->vector upper)))))
+            (list->vector upper)))))
 
 (pp "interval-projections error tests")
 
@@ -282,17 +282,17 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 3 11)))))
-	 (upper (map (lambda (x) (+ (random 1 11) x)) lower))
-	 (left-dimension (random 1 (- (length lower) 1)))
-	 (right-dimension (- (length lower) left-dimension)))
+         (upper (map (lambda (x) (+ (random 1 11) x)) lower))
+         (left-dimension (random 1 (- (length lower) 1)))
+         (right-dimension (- (length lower) left-dimension)))
     (test-multiple-values
      (interval-projections (make-interval (list->vector lower)
                                           (list->vector upper))
                            right-dimension)
      (list (make-interval (list->vector (take lower left-dimension))
-			  (list->vector (take upper left-dimension)))
-	   (make-interval (list->vector (drop lower left-dimension))
-			  (list->vector (drop upper left-dimension)))))))
+                          (list->vector (take upper left-dimension)))
+           (make-interval (list->vector (drop lower left-dimension))
+                          (list->vector (drop upper left-dimension)))))))
 
 
 (pp "interval-contains-multi-index? error tests")
@@ -309,10 +309,10 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 1 11)))))
-	 (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
+         (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
     (test (interval-volume (make-interval (list->vector lower)
-					  (list->vector upper)))
-	  (apply * (map - upper lower)))))
+                                          (list->vector upper)))
+          (apply * (map - upper lower)))))
 
 (pp "interval= error tests")
 
@@ -327,15 +327,15 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower1 (map (lambda (x) (random 2)) (vector->list (make-vector (random 1 6)))))
-	 (upper1 (map (lambda (x) (+ (random 1 3) x)) lower1))
-	 (lower2 (map (lambda (x) (random 2)) lower1))
-	 (upper2 (map (lambda (x) (+ 1 (random 1 3) x)) lower2)))
+         (upper1 (map (lambda (x) (+ (random 1 3) x)) lower1))
+         (lower2 (map (lambda (x) (random 2)) lower1))
+         (upper2 (map (lambda (x) (+ 1 (random 1 3) x)) lower2)))
     (test (interval= (make-interval (list->vector lower1)
-				    (list->vector upper1))
-		     (make-interval (list->vector lower2)
-				    (list->vector upper2)))
-	  (and (equal? lower1 lower2)                              ;; the probability of this happening is about 1/16
-	       (equal? upper1 upper2)))))
+                                    (list->vector upper1))
+                     (make-interval (list->vector lower2)
+                                    (list->vector upper2)))
+          (and (equal? lower1 lower2)                              ;; the probability of this happening is about 1/16
+               (equal? upper1 upper2)))))
 
 (pp "interval-subset? error tests")
 
@@ -354,15 +354,15 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower1 (map (lambda (x) (random 2)) (vector->list (make-vector (random 1 6)))))
-	 (upper1 (map (lambda (x) (+ (random 1 3) x)) lower1))
-	 (lower2 (map (lambda (x) (random 2)) lower1))
-	 (upper2 (map (lambda (x) (+ (random 1 3) x)) lower2)))
+         (upper1 (map (lambda (x) (+ (random 1 3) x)) lower1))
+         (lower2 (map (lambda (x) (random 2)) lower1))
+         (upper2 (map (lambda (x) (+ (random 1 3) x)) lower2)))
     (test (interval-subset? (make-interval (list->vector lower1)
-					   (list->vector upper1))
-			    (make-interval (list->vector lower2)
-					   (list->vector upper2)))
-	  (and (%%every >= lower1 lower2)
-	       (%%every <= upper1 upper2)))))
+                                           (list->vector upper1))
+                            (make-interval (list->vector lower2)
+                                           (list->vector upper2)))
+          (and (%%every >= lower1 lower2)
+               (%%every <= upper1 upper2)))))
 
 (pp "interval-contains-multi-index?  error tests")
 
@@ -407,47 +407,47 @@
   (if (null? (cdr lower))
       (map list (local-iota (car lower) (car upper)))
       (apply append (map (lambda (x)
-			   (map (lambda (y)
-				  (cons x y))
-				(all-elements (cdr lower) (cdr upper))))
-			 (local-iota (car lower) (car upper))))))
+                           (map (lambda (y)
+                                  (cons x y))
+                                (all-elements (cdr lower) (cdr upper))))
+                         (local-iota (car lower) (car upper))))))
 
 (pp "interval-for-each result tests")
 
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower (map (lambda (x) (random 10))
-		     (vector->list (make-vector (random 1 7)))))
-	 (upper (map (lambda (x) (+ (random 1 4) x))
-		     lower)))
+                     (vector->list (make-vector (random 1 7)))))
+         (upper (map (lambda (x) (+ (random 1 4) x))
+                     lower)))
     (let ((result '()))
 
       (define (f . args)
-	(set! result (cons args result)))
+        (set! result (cons args result)))
 
       (test (let ()
-	      (interval-for-each f
-				 (make-interval (list->vector lower)
-						(list->vector upper)))
-	      result)
-	    (reverse (all-elements lower upper))))))
+              (interval-for-each f
+                                 (make-interval (list->vector lower)
+                                                (list->vector upper)))
+              result)
+            (reverse (all-elements lower upper))))))
 
 
 (pp "interval-dilate error tests")
 
 (let ((interval (make-interval '#(0 0) '#(100 100))))
   (test (interval-dilate interval 'a '#(-10 10))
-	"interval-dilate: The second argument is not a vector of exact integers: ")
+        "interval-dilate: The second argument is not a vector of exact integers: ")
   (test (interval-dilate 'a '#(10 10) '#(-10 -10))
-	"interval-dilate: The first argument is not an interval: ")
+        "interval-dilate: The first argument is not an interval: ")
   (test (interval-dilate interval '#(10 10) 'a)
-"interval-dilate: The third argument is not a vector of exact integers: "	)
+"interval-dilate: The third argument is not a vector of exact integers: "       )
   (test (interval-dilate interval '#(10) '#(-10 -10))
-	"interval-dilate: The second and third arguments must have the same length as the dimension of the first argument: ")
+        "interval-dilate: The second and third arguments must have the same length as the dimension of the first argument: ")
   (test (interval-dilate interval '#(10 10) '#( -10))
-	"interval-dilate: The second and third arguments must have the same length as the dimension of the first argument: ")
+        "interval-dilate: The second and third arguments must have the same length as the dimension of the first argument: ")
   (test (interval-dilate interval '#(100 100) '#(-100 -100))
-	"interval-dilate: The resulting interval is empty: "))
+        "interval-dilate: The resulting interval is empty: "))
 
 
 
@@ -455,27 +455,27 @@
 
 (define (random-multi-index interval)
   (apply values
-	 (apply map
-		random
-		(map (lambda (bounds)
-		       (bounds interval))
-		     (list interval-lower-bounds->list
-			   interval-upper-bounds->list)))))
+         (apply map
+                random
+                (map (lambda (bounds)
+                       (bounds interval))
+                     (list interval-lower-bounds->list
+                           interval-upper-bounds->list)))))
 
 
 (define (random-interval #!optional (min 1) (max 8) )
   ;; a random interval with min <= dimension < max
   ;; positive and negative lower bounds
   (let* ((lower
-	  (map (lambda (x)
-		 (random -10 10))
-	       (vector->list (make-vector (random min max)))))
-	 (upper
-	  (map (lambda (x)
-		 (+ (random 1 8) x))
-	       lower)))
+          (map (lambda (x)
+                 (random -10 10))
+               (vector->list (make-vector (random min max)))))
+         (upper
+          (map (lambda (x)
+                 (+ (random 1 8) x))
+               lower)))
     (make-interval (list->vector lower)
-		   (list->vector upper))))
+                   (list->vector upper))))
 
 (define (random-subinterval interval)
   (let* ((lowers (interval-lower-bounds->vector interval))
@@ -491,15 +491,15 @@
   ;; a random interval with min <= dimension < max
   ;; positive and negative lower bounds
   (let* ((lower
-	  (map (lambda (x)
-		 0)
-	       (vector->list (make-vector (random min max)))))
-	 (upper
-	  (map (lambda (x)
-		 (+ (random 1 11) x))
-	       lower)))
+          (map (lambda (x)
+                 0)
+               (vector->list (make-vector (random min max)))))
+         (upper
+          (map (lambda (x)
+                 (+ (random 1 11) x))
+               lower)))
     (make-interval (list->vector lower)
-		   (list->vector upper))))
+                   (list->vector upper))))
 
 (define (random-positive-vector n #!optional (max 5))
   (vector-map (lambda (x)
@@ -531,13 +531,13 @@
 
 (let ((getter (lambda args 1.)))
   (test (make-array (make-interval '#(3) '#(4)) getter)
-	(make-%%array (make-interval '#(3) '#(4))
-			   getter
-			   #f
-			   #f
-			   #f
-			   #f
-			   #f)))
+        (make-%%array (make-interval '#(3) '#(4))
+                           getter
+                           #f
+                           #f
+                           #f
+                           #f
+                           #f)))
 
 (pp "array-domain and array-getter error tests")
 
@@ -552,31 +552,31 @@
 (let* ((getter (lambda args 1.))
        (array    (make-array (make-interval '#(3) '#(4)) getter)))
   (test (array? #f)
-	#f)
+        #f)
   (test (array? array)
-	#t)
+        #t)
   (test (array-domain array)
-	(make-interval '#(3) '#(4)))
+        (make-interval '#(3) '#(4)))
   (test (array-getter array)
-	getter))
+        getter))
 
 
 (pp "mutable-array result tests")
 
 (let ((result #f))
   (let ((getter (lambda (i) result))
-	(setter   (lambda (v i) (set! result v)))
-	(domain   (make-interval '#(3) '#(4))))
+        (setter   (lambda (v i) (set! result v)))
+        (domain   (make-interval '#(3) '#(4))))
     (test (make-array domain
-		      getter
-		      setter)
-	  (make-%%array domain
-			     getter
-			     setter
-			     #f
-			     #f
-			     #f
-			     #f))))
+                      getter
+                      setter)
+          (make-%%array domain
+                             getter
+                             setter
+                             #f
+                             #f
+                             #f
+                             #f))))
 
 (pp "array-setter error tests")
 
@@ -587,23 +587,23 @@
 
 (let ((result (cons #f #f)))
   (let ((getter (lambda (i) (car result)))
-	(setter   (lambda (v i) (set-car! result v)))
-	(domain   (make-interval '#(3) '#(4))))
+        (setter   (lambda (v i) (set-car! result v)))
+        (domain   (make-interval '#(3) '#(4))))
     (let ((array (make-array domain
-			     getter
-			     setter)))
+                             getter
+                             setter)))
       (test (array? array)
-	    #t)
+            #t)
       (test (mutable-array? array)
-	    #t)
+            #t)
       (test (mutable-array? 1)
-	    #f)
+            #f)
       (test (array-setter array)
-	    setter)
+            setter)
       (test (array-getter array)
-	    getter)
+            getter)
       (test (array-domain array)
-	    domain))))
+            domain))))
 
 (define (myindexer= indexer1 indexer2 interval)
   (array-fold (lambda (x y) (and x y))
@@ -628,52 +628,52 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower-bounds
-	  (map (lambda (x) (random 2))
-	       (vector->list (make-vector (random 1 7)))))
-	 (upper-bounds
-	  (map (lambda (x) (+ x (random 1 3)))
-	       lower-bounds))
-	 (new-domain
-	  (make-interval (list->vector lower-bounds)
-			 (list->vector upper-bounds)))
-	 (new-domain-dimension
-	  (interval-dimension new-domain))
-	 (old-domain-dimension
-	  (random 1 7))
-	 (base
-	  (random 100))
-	 (coefficients
-	  (map (lambda (x) (* (random-sign)
-			      (random 20)))
-	       (local-iota 0 old-domain-dimension)))
-	 (old-indexer
-	  (lambda args
-	    (apply + base (map * args coefficients))))
-	 (new-domain->old-domain-coefficients
-	  (map (lambda (x)
-		 (map (lambda (x) (* (random-sign) (random 10)))
-		      (local-iota 0 new-domain-dimension)))
-	       (local-iota 0 old-domain-dimension)))
-	 (new-domain->old-domain
-	  (lambda args
-	    (apply values (map (lambda (row)
-				 (apply + (map * row args)))
-			       new-domain->old-domain-coefficients)))))
+          (map (lambda (x) (random 2))
+               (vector->list (make-vector (random 1 7)))))
+         (upper-bounds
+          (map (lambda (x) (+ x (random 1 3)))
+               lower-bounds))
+         (new-domain
+          (make-interval (list->vector lower-bounds)
+                         (list->vector upper-bounds)))
+         (new-domain-dimension
+          (interval-dimension new-domain))
+         (old-domain-dimension
+          (random 1 7))
+         (base
+          (random 100))
+         (coefficients
+          (map (lambda (x) (* (random-sign)
+                              (random 20)))
+               (local-iota 0 old-domain-dimension)))
+         (old-indexer
+          (lambda args
+            (apply + base (map * args coefficients))))
+         (new-domain->old-domain-coefficients
+          (map (lambda (x)
+                 (map (lambda (x) (* (random-sign) (random 10)))
+                      (local-iota 0 new-domain-dimension)))
+               (local-iota 0 old-domain-dimension)))
+         (new-domain->old-domain
+          (lambda args
+            (apply values (map (lambda (row)
+                                 (apply + (map * row args)))
+                               new-domain->old-domain-coefficients)))))
     (if (not (and (myindexer= (lambda args
-				(call-with-values
-				    (lambda () (apply new-domain->old-domain args))
-				  old-indexer))
-			      (%%compose-indexers old-indexer new-domain  new-domain->old-domain)
-			      new-domain)))
-	(pp (list new-domain
-		  old-domain-dimension
-		  base
-		  coefficients
-		  new-domain->old-domain-coefficients)))))
+                                (call-with-values
+                                    (lambda () (apply new-domain->old-domain args))
+                                  old-indexer))
+                              (%%compose-indexers old-indexer new-domain  new-domain->old-domain)
+                              new-domain)))
+        (pp (list new-domain
+                  old-domain-dimension
+                  base
+                  coefficients
+                  new-domain->old-domain-coefficients)))))
 
 (define (myarray= array1 array2)
   (and (interval= (array-domain array1)
-		  (array-domain array2))
+                  (array-domain array2))
        (array-fold (lambda (vs result)
                      (and (equal? (car vs)
                                   (cadr vs))
@@ -684,16 +684,16 @@
 (pp "array body, indexer, storage-class, and safe? error tests")
 
 (let ((a (make-array (make-interval '#(0 0) '#(1 1)) ;; not valid
-		     values
-		     values)))
+                     values
+                     values)))
   (test (array-body a)
-	"array-body: The argument is not a specialized array: ")
+        "array-body: The argument is not a specialized array: ")
   (test (array-indexer a)
-	"array-indexer: The argument is not a specialized array: ")
+        "array-indexer: The argument is not a specialized array: ")
   (test (array-storage-class a)
-	"array-storage-class: The argument is not a specialized array: ")
+        "array-storage-class: The argument is not a specialized array: ")
   (test (array-safe? a)
-	"array-safe?: The argument is not a specialized array: "))
+        "array-safe?: The argument is not a specialized array: "))
 
 (pp "specialized-array error tests")
 
@@ -932,41 +932,41 @@
       "array->specialized-array: The first argument is not an array: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1) '#(2))
-					    list)
-				#f)
+                                            list)
+                                #f)
       "array->specialized-array: The second argument is not a storage-class: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1) '#(2))
-					    list)
-				generic-storage-class
-				'a)
+                                            list)
+                                generic-storage-class
+                                'a)
       "array->specialized-array: The third argument is not a boolean: ")
 
 ;; We gotta make sure than the error checks work in all dimensions ...
 
 (test (array->specialized-array (make-array (make-interval '#(1) '#(2))
-					    list)
-				u16-storage-class)
+                                            list)
+                                u16-storage-class)
       "array->specialized-array: not all elements of the array can be manipulated by the storage class: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1 1) '#(2 2))
-					    list)
-				u16-storage-class)
+                                            list)
+                                u16-storage-class)
       "array->specialized-array: not all elements of the array can be manipulated by the storage class: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1 1 1) '#(2 2 2))
-					    list)
-				u16-storage-class)
+                                            list)
+                                u16-storage-class)
       "array->specialized-array: not all elements of the array can be manipulated by the storage class: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1 1 1 1) '#(2 2 2 2))
-					    list)
-				u16-storage-class)
+                                            list)
+                                u16-storage-class)
       "array->specialized-array: not all elements of the array can be manipulated by the storage class: ")
 
 (test (array->specialized-array (make-array (make-interval '#(1 1 1 1 1) '#(2 2 2 2 2))
-					    list)
-				u16-storage-class)
+                                            list)
+                                u16-storage-class)
       "array->specialized-array: not all elements of the array can be manipulated by the storage class: ")
 
 (test (specialized-array-default-safe? 'a)
@@ -982,42 +982,42 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower-bounds
-	  (map (lambda (x) (random 4))
-	       (vector->list (make-vector (random 1 7)))))
-	 (upper-bounds
-	  (map (lambda (x) (+ x (random 1 5)))
-	       lower-bounds))
-	 (domain
-	  (make-interval (list->vector lower-bounds)
-			 (list->vector upper-bounds)))
-	 (array1
-	  (let ((alist '()))
-	    (make-array
-	     domain
-	     (lambda indices
-	       (cond ((assoc indices alist)
-		      => cdr)
-		     (else
-		      indices)))
-	     (lambda (value . indices)
-	       (cond ((assoc indices alist)
-		      =>(lambda (entry)
-			  (set-cdr! entry value)))
-		     (else
-		      (set! alist (cons (cons indices value)
-					alist))))))))
-	 (array2
-	  (array->specialized-array array1 generic-storage-class))
-	 (setter1
-	  (array-setter array1))
-	 (setter2
-	  (array-setter array2)))
+          (map (lambda (x) (random 4))
+               (vector->list (make-vector (random 1 7)))))
+         (upper-bounds
+          (map (lambda (x) (+ x (random 1 5)))
+               lower-bounds))
+         (domain
+          (make-interval (list->vector lower-bounds)
+                         (list->vector upper-bounds)))
+         (array1
+          (let ((alist '()))
+            (make-array
+             domain
+             (lambda indices
+               (cond ((assoc indices alist)
+                      => cdr)
+                     (else
+                      indices)))
+             (lambda (value . indices)
+               (cond ((assoc indices alist)
+                      =>(lambda (entry)
+                          (set-cdr! entry value)))
+                     (else
+                      (set! alist (cons (cons indices value)
+                                        alist))))))))
+         (array2
+          (array->specialized-array array1 generic-storage-class))
+         (setter1
+          (array-setter array1))
+         (setter2
+          (array-setter array2)))
     (do ((j 0 (+ j 1)))
-	((= j 25))
+        ((= j 25))
       (let ((v (random 1000))
-	    (indices (map random lower-bounds upper-bounds)))
-	(apply setter1 v indices)
-	(apply setter2 v indices)))
+            (indices (map random lower-bounds upper-bounds)))
+        (apply setter1 v indices)
+        (apply setter2 v indices)))
     (or (myarray= array1 array2) (pp "test1"))
     (or (myarray= (array->specialized-array        array1 generic-storage-class ) array2) (pp "test3"))
     ))
@@ -1029,42 +1029,42 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((lower-bounds
-	  (map (lambda (x) (random 4))
-	       (vector->list (make-vector (random 1 7)))))
-	 (upper-bounds
-	  (map (lambda (x) (+ x (random 1 5)))
-	       lower-bounds))
-	 (domain
-	  (make-interval (list->vector lower-bounds)
-			 (list->vector upper-bounds)))
-	 (array1
-	  (let ((alist '()))
-	    (make-array
-	     domain
-	     (lambda indices
-	       (cond ((assoc indices alist)
-		      => cdr)
-		     (else
-		      indices)))
-	     (lambda (value . indices)
-	       (cond ((assoc indices alist)
-		      =>(lambda (entry)
-			  (set-cdr! entry value)))
-		     (else
-		      (set! alist (cons (cons indices value)
-					alist))))))))
-	 (array2
-	  (array->specialized-array array1 generic-storage-class ))
-	 (setter1
-	  (array-setter array1))
-	 (setter2
-	  (array-setter array2)))
+          (map (lambda (x) (random 4))
+               (vector->list (make-vector (random 1 7)))))
+         (upper-bounds
+          (map (lambda (x) (+ x (random 1 5)))
+               lower-bounds))
+         (domain
+          (make-interval (list->vector lower-bounds)
+                         (list->vector upper-bounds)))
+         (array1
+          (let ((alist '()))
+            (make-array
+             domain
+             (lambda indices
+               (cond ((assoc indices alist)
+                      => cdr)
+                     (else
+                      indices)))
+             (lambda (value . indices)
+               (cond ((assoc indices alist)
+                      =>(lambda (entry)
+                          (set-cdr! entry value)))
+                     (else
+                      (set! alist (cons (cons indices value)
+                                        alist))))))))
+         (array2
+          (array->specialized-array array1 generic-storage-class ))
+         (setter1
+          (array-setter array1))
+         (setter2
+          (array-setter array2)))
     (do ((j 0 (+ j 1)))
-	((= j 25))
+        ((= j 25))
       (let ((v (random 1000))
-	    (indices (map random lower-bounds upper-bounds)))
-	(apply setter1 v indices)
-	(apply setter2 v indices)))
+            (indices (map random lower-bounds upper-bounds)))
+        (apply setter1 v indices)
+        (apply setter2 v indices)))
     (or (myarray= array1 array2) (pp "test1"))
     (or (myarray= (array->specialized-array        array1 generic-storage-class ) array2) (pp "test3"))
     ))
@@ -1075,18 +1075,18 @@
       "array-map: The first argument is not a procedure: ")
 
 (test (array-map list 1 (make-array (make-interval '#(3) '#(4))
-				    list))
+                                    list))
       "array-map: Not all arguments after the first are arrays: ")
 
 (test (array-map list (make-array (make-interval '#(3) '#(4))
-				  list) 1)
+                                  list) 1)
       "array-map: Not all arguments after the first are arrays: ")
 
 (test (array-map list
-		 (make-array (make-interval '#(3) '#(4))
-			     list)
-		 (make-array (make-interval '#(3 4) '#(4 5))
-			     list))
+                 (make-array (make-interval '#(3) '#(4))
+                             list)
+                 (make-array (make-interval '#(3 4) '#(4 5))
+                             list))
       "array-map: Not all arguments after the first have the same domain: ")
 
 (pp "array-every and array-any error tests")
@@ -1229,18 +1229,18 @@
       "array-for-each: The first argument is not a procedure: ")
 
 (test (array-for-each list 1 (make-array (make-interval '#(3) '#(4))
-					 list))
+                                         list))
       "array-for-each: Not all arguments after the first are arrays: ")
 
 (test (array-for-each list (make-array (make-interval '#(3) '#(4))
-				       list) 1)
+                                       list) 1)
       "array-for-each: Not all arguments after the first are arrays: ")
 
 (test (array-for-each list
-		      (make-array (make-interval '#(3) '#(4))
-				  list)
-		      (make-array (make-interval '#(3 4) '#(4 5))
-				  list))
+                      (make-array (make-interval '#(3) '#(4))
+                                  list)
+                      (make-array (make-interval '#(3 4) '#(4 5))
+                                  list))
       "array-for-each: Not all arguments after the first have the same domain: ")
 
 
@@ -1249,140 +1249,140 @@
 (specialized-array-default-safe? #t)
 
 (let ((array-builders (vector (list u1-storage-class      (lambda indices (random 0 (expt 2 1))))
-			      (list u8-storage-class      (lambda indices (random 0 (expt 2 8))))
-			      (list u16-storage-class     (lambda indices (random 0 (expt 2 16))))
-			      (list u32-storage-class     (lambda indices (random 0 (expt 2 32))))
-			      (list u64-storage-class     (lambda indices (random 0 (expt 2 64))))
-			      (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
-			      (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
-			      (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
-			      (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-			      (list f32-storage-class     (lambda indices (random-real)))
-			      (list f64-storage-class     (lambda indices (random-real)))
-			      (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
-			      (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
-			      (list generic-storage-class (lambda indices indices)))))
+                              (list u8-storage-class      (lambda indices (random 0 (expt 2 8))))
+                              (list u16-storage-class     (lambda indices (random 0 (expt 2 16))))
+                              (list u32-storage-class     (lambda indices (random 0 (expt 2 32))))
+                              (list u64-storage-class     (lambda indices (random 0 (expt 2 64))))
+                              (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
+                              (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
+                              (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
+                              (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
+                              (list f32-storage-class     (lambda indices (random-real)))
+                              (list f64-storage-class     (lambda indices (random-real)))
+                              (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((lower-bounds
-	    (map (lambda (x) (random 4))
-		 (vector->list (make-vector (random 1 10)))))
-	   (upper-bounds
-	    (map (lambda (x) (+ x (random 1 4)))
-		 lower-bounds))
-	   (array-length
-	    (lambda (a)
-	      (let ((upper-bounds (interval-upper-bounds->list (array-domain a)))
-		    (lower-bounds (interval-lower-bounds->list (array-domain a))))
-		(apply * (map - upper-bounds lower-bounds)))))
-	   (domain
-	    (make-interval (list->vector lower-bounds)
-			   (list->vector upper-bounds)))
-	   (arrays
-	    (map (lambda (ignore)
-		   (let ((array-builder (vector-ref array-builders (random (vector-length array-builders)))))
-		     (array->specialized-array (make-array domain
-							   (cadr array-builder))
-					       (car array-builder)
-					       )))
-		 (local-iota 0 (random 1 7))))
-	   (result-array-1
-	    (apply array-map
-		   list
-		   arrays))
-	   (result-array-2
-	    (array->specialized-array
-	     (apply array-map
-		    list
-		    arrays)))
-	   (getters
-	    (map array-getter arrays))
-	   (result-array-3
-	    (make-array domain
-			(lambda indices
-			  (map (lambda (g) (apply g indices)) getters)))))
+            (map (lambda (x) (random 4))
+                 (vector->list (make-vector (random 1 10)))))
+           (upper-bounds
+            (map (lambda (x) (+ x (random 1 4)))
+                 lower-bounds))
+           (array-length
+            (lambda (a)
+              (let ((upper-bounds (interval-upper-bounds->list (array-domain a)))
+                    (lower-bounds (interval-lower-bounds->list (array-domain a))))
+                (apply * (map - upper-bounds lower-bounds)))))
+           (domain
+            (make-interval (list->vector lower-bounds)
+                           (list->vector upper-bounds)))
+           (arrays
+            (map (lambda (ignore)
+                   (let ((array-builder (vector-ref array-builders (random (vector-length array-builders)))))
+                     (array->specialized-array (make-array domain
+                                                           (cadr array-builder))
+                                               (car array-builder)
+                                               )))
+                 (local-iota 0 (random 1 7))))
+           (result-array-1
+            (apply array-map
+                   list
+                   arrays))
+           (result-array-2
+            (array->specialized-array
+             (apply array-map
+                    list
+                    arrays)))
+           (getters
+            (map array-getter arrays))
+           (result-array-3
+            (make-array domain
+                        (lambda indices
+                          (map (lambda (g) (apply g indices)) getters)))))
       (if (not (and (myarray= result-array-1 result-array-2)
-		    (myarray= result-array-2 result-array-3)
-		    (equal? (vector->list (array-body result-array-2))
-			    (reverse (array-fold (lambda (x y) (cons x y))
-						   '()
-						   result-array-2)))
-		    (equal? (vector->list (array-body result-array-2))
-			    (reverse (let ((result '()))
-				       (array-for-each (lambda (f)
-							 (set! result (cons f result)))
-						       result-array-2)
-				       result)))
-		    (equal?  (map array-length arrays)
-			     (map (lambda (array)
-				    ((storage-class-length (array-storage-class array)) (array-body array)))
-				  arrays))))
-	  (pp "Arghh"))
+                    (myarray= result-array-2 result-array-3)
+                    (equal? (vector->list (array-body result-array-2))
+                            (reverse (array-fold (lambda (x y) (cons x y))
+                                                   '()
+                                                   result-array-2)))
+                    (equal? (vector->list (array-body result-array-2))
+                            (reverse (let ((result '()))
+                                       (array-for-each (lambda (f)
+                                                         (set! result (cons f result)))
+                                                       result-array-2)
+                                       result)))
+                    (equal?  (map array-length arrays)
+                             (map (lambda (array)
+                                    ((storage-class-length (array-storage-class array)) (array-body array)))
+                                  arrays))))
+          (pp "Arghh"))
       )))
 
 (specialized-array-default-safe? #f)
 
 (let ((array-builders (vector (list u1-storage-class      (lambda indices (random (expt 2 1))))
-			      (list u8-storage-class      (lambda indices (random (expt 2 8))))
-			      (list u16-storage-class     (lambda indices (random (expt 2 16))))
-			      (list u32-storage-class     (lambda indices (random (expt 2 32))))
-			      (list u64-storage-class     (lambda indices (random (expt 2 64))))
-			      (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
-			      (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
-			      (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
-			      (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-			      (list f32-storage-class     (lambda indices (random-real)))
-			      (list f64-storage-class     (lambda indices (random-real)))
+                              (list u8-storage-class      (lambda indices (random (expt 2 8))))
+                              (list u16-storage-class     (lambda indices (random (expt 2 16))))
+                              (list u32-storage-class     (lambda indices (random (expt 2 32))))
+                              (list u64-storage-class     (lambda indices (random (expt 2 64))))
+                              (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
+                              (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
+                              (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
+                              (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
+                              (list f32-storage-class     (lambda indices (random-real)))
+                              (list f64-storage-class     (lambda indices (random-real)))
                               (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
                               (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
-			      (list generic-storage-class (lambda indices indices)))))
+                              (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((lower-bounds
-	    (map (lambda (x) (random 4))
-		 (vector->list (make-vector (random 1 10)))))
-	   (upper-bounds
-	    (map (lambda (x) (+ x (random 1 4)))
-		 lower-bounds))
-	   (domain
-	    (make-interval (list->vector lower-bounds)
-			   (list->vector upper-bounds)))
-	   (arrays
-	    (map (lambda (ignore)
-		   (let ((array-builder (vector-ref array-builders (random (vector-length array-builders)))))
-		     (array->specialized-array (make-array domain
-							   (cadr array-builder))
-					       (car array-builder)
-					       )))
-		 (local-iota 0 (random 1 7))))
-	   (result-array-1
-	    (apply array-map
-		   list
-		   arrays))
-	   (result-array-2
-	    (array->specialized-array
-	     (apply array-map
-		    list
-		    arrays)))
-	   (getters
-	    (map array-getter arrays))
-	   (result-array-3
-	    (make-array domain
-			(lambda indices
-			  (map (lambda (g) (apply g indices)) getters)))))
+            (map (lambda (x) (random 4))
+                 (vector->list (make-vector (random 1 10)))))
+           (upper-bounds
+            (map (lambda (x) (+ x (random 1 4)))
+                 lower-bounds))
+           (domain
+            (make-interval (list->vector lower-bounds)
+                           (list->vector upper-bounds)))
+           (arrays
+            (map (lambda (ignore)
+                   (let ((array-builder (vector-ref array-builders (random (vector-length array-builders)))))
+                     (array->specialized-array (make-array domain
+                                                           (cadr array-builder))
+                                               (car array-builder)
+                                               )))
+                 (local-iota 0 (random 1 7))))
+           (result-array-1
+            (apply array-map
+                   list
+                   arrays))
+           (result-array-2
+            (array->specialized-array
+             (apply array-map
+                    list
+                    arrays)))
+           (getters
+            (map array-getter arrays))
+           (result-array-3
+            (make-array domain
+                        (lambda indices
+                          (map (lambda (g) (apply g indices)) getters)))))
       (if (not (and (myarray= result-array-1 result-array-2)
-		    (myarray= result-array-2 result-array-3)
-		    (equal? (vector->list (array-body result-array-2))
-			    (reverse (array-fold cons
+                    (myarray= result-array-2 result-array-3)
+                    (equal? (vector->list (array-body result-array-2))
+                            (reverse (array-fold cons
                                                  '()
                                                  result-array-2)))
-		    (equal? (vector->list (array-body result-array-2))
-			    (reverse (let ((result '()))
-				       (array-for-each (lambda (f)
-							 (set! result (cons f result)))
-						       result-array-2)
-				       result)))))
-	  (pp "Arghh")))))
+                    (equal? (vector->list (array-body result-array-2))
+                            (reverse (let ((result '()))
+                                       (array-for-each (lambda (f)
+                                                         (set! result (cons f result)))
+                                                       result-array-2)
+                                       result)))))
+          (pp "Arghh")))))
 
 (pp "array-reduce tests")
 
@@ -1522,134 +1522,134 @@
 
 
 (let ((array-builders (vector (list u1-storage-class      (lambda indices (random (expt 2 1))))
-			      (list u8-storage-class      (lambda indices (random (expt 2 8))))
-			      (list u16-storage-class     (lambda indices (random (expt 2 16))))
-			      (list u32-storage-class     (lambda indices (random (expt 2 32))))
-			      (list u64-storage-class     (lambda indices (random (expt 2 64))))
-			      (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
-			      (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
-			      (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
-			      (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-			      (list f32-storage-class     (lambda indices (random-real)))
-			      (list f64-storage-class     (lambda indices (random-real)))
+                              (list u8-storage-class      (lambda indices (random (expt 2 8))))
+                              (list u16-storage-class     (lambda indices (random (expt 2 16))))
+                              (list u32-storage-class     (lambda indices (random (expt 2 32))))
+                              (list u64-storage-class     (lambda indices (random (expt 2 64))))
+                              (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
+                              (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
+                              (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
+                              (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
+                              (list f32-storage-class     (lambda indices (random-real)))
+                              (list f64-storage-class     (lambda indices (random-real)))
                               (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
                               (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
-			      (list generic-storage-class (lambda indices indices)))))
+                              (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((lower-bounds
-	    (map (lambda (x) (random 4))
-		 (vector->list (make-vector (random 2 7)))))
-	   (upper-bounds
-	    (map (lambda (x) (+ x (random 1 5)))
-		 lower-bounds))
-	   (domain
-	    (make-interval (list->vector lower-bounds)
-			   (list->vector upper-bounds)))
-	   (array-builder
-	    (vector-ref array-builders (random (vector-length array-builders))))
-	   (random-array-element
-	    (cadr array-builder))
-	   (storage-class
-	    (car array-builder))
-	   (Array
-	    (array->specialized-array (make-array domain
-						  random-array-element)
-				      storage-class))
-	   (copied-array
-	    (array->specialized-array Array
-				      storage-class))
-	   (inner-dimension
-	    (random 1 (interval-dimension domain)))
-	   (domains
-	    (call-with-values (lambda ()(interval-projections domain inner-dimension)) list))
-	   (outer-domain
-	    (car domains))
-	   (inner-domain
-	    (cadr domains))
-	   (immutable-curry
-	    (array-curry (make-array (array-domain Array)
-				     (array-getter Array))
-			 inner-dimension))
-	   (mutable-curry
-	    (array-curry (make-array (array-domain Array)
-				     (array-getter Array)
-				     (array-setter Array))
-			 inner-dimension))
-	   (specialized-curry
-	    (array-curry Array inner-dimension))
-	   (immutable-curry-from-definition
-	    (call-with-values
-		(lambda () (interval-projections (array-domain Array) inner-dimension))
-	      (lambda (outer-interval inner-interval)
-		(make-array outer-interval
-			    (lambda outer-multi-index
-			      (make-array inner-interval
-					  (lambda inner-multi-index
-					    (apply (array-getter Array) (append outer-multi-index inner-multi-index)))))))))
-	   (mutable-curry-from-definition
-	    (call-with-values
-		(lambda () (interval-projections (array-domain Array) inner-dimension))
-	      (lambda (outer-interval inner-interval)
-		(make-array outer-interval
-			    (lambda outer-multi-index
-			      (make-array inner-interval
-					  (lambda inner-multi-index
-					    (apply (array-getter Array) (append outer-multi-index inner-multi-index)))
-					  (lambda (v . inner-multi-index)
-					    (apply (array-setter Array) v (append outer-multi-index inner-multi-index)))))))))
-	   (specialized-curry-from-definition
-	    (call-with-values
-		(lambda () (interval-projections (array-domain Array) inner-dimension))
-	      (lambda (outer-interval inner-interval)
-		(make-array outer-interval
-			    (lambda outer-multi-index
-			      (specialized-array-share Array
-						       inner-interval
-						       (lambda inner-multi-index
-							 (apply values (append outer-multi-index inner-multi-index))))))))))
+            (map (lambda (x) (random 4))
+                 (vector->list (make-vector (random 2 7)))))
+           (upper-bounds
+            (map (lambda (x) (+ x (random 1 5)))
+                 lower-bounds))
+           (domain
+            (make-interval (list->vector lower-bounds)
+                           (list->vector upper-bounds)))
+           (array-builder
+            (vector-ref array-builders (random (vector-length array-builders))))
+           (random-array-element
+            (cadr array-builder))
+           (storage-class
+            (car array-builder))
+           (Array
+            (array->specialized-array (make-array domain
+                                                  random-array-element)
+                                      storage-class))
+           (copied-array
+            (array->specialized-array Array
+                                      storage-class))
+           (inner-dimension
+            (random 1 (interval-dimension domain)))
+           (domains
+            (call-with-values (lambda ()(interval-projections domain inner-dimension)) list))
+           (outer-domain
+            (car domains))
+           (inner-domain
+            (cadr domains))
+           (immutable-curry
+            (array-curry (make-array (array-domain Array)
+                                     (array-getter Array))
+                         inner-dimension))
+           (mutable-curry
+            (array-curry (make-array (array-domain Array)
+                                     (array-getter Array)
+                                     (array-setter Array))
+                         inner-dimension))
+           (specialized-curry
+            (array-curry Array inner-dimension))
+           (immutable-curry-from-definition
+            (call-with-values
+                (lambda () (interval-projections (array-domain Array) inner-dimension))
+              (lambda (outer-interval inner-interval)
+                (make-array outer-interval
+                            (lambda outer-multi-index
+                              (make-array inner-interval
+                                          (lambda inner-multi-index
+                                            (apply (array-getter Array) (append outer-multi-index inner-multi-index)))))))))
+           (mutable-curry-from-definition
+            (call-with-values
+                (lambda () (interval-projections (array-domain Array) inner-dimension))
+              (lambda (outer-interval inner-interval)
+                (make-array outer-interval
+                            (lambda outer-multi-index
+                              (make-array inner-interval
+                                          (lambda inner-multi-index
+                                            (apply (array-getter Array) (append outer-multi-index inner-multi-index)))
+                                          (lambda (v . inner-multi-index)
+                                            (apply (array-setter Array) v (append outer-multi-index inner-multi-index)))))))))
+           (specialized-curry-from-definition
+            (call-with-values
+                (lambda () (interval-projections (array-domain Array) inner-dimension))
+              (lambda (outer-interval inner-interval)
+                (make-array outer-interval
+                            (lambda outer-multi-index
+                              (specialized-array-share Array
+                                                       inner-interval
+                                                       (lambda inner-multi-index
+                                                         (apply values (append outer-multi-index inner-multi-index))))))))))
       ;; mutate the curried array
       (for-each (lambda (curried-array)
-		  (let ((outer-getter
-			 (array-getter curried-array)))
-		    (do ((i 0 (+ i 1)))
-			((= i 50))  ;; used to be tests, not 50, but 50 will do fine
-		      (call-with-values
-			  (lambda ()
-			    (random-multi-index outer-domain))
-			(lambda outer-multi-index
-			  (let ((inner-setter
-				 (array-setter (apply outer-getter outer-multi-index))))
-			    (call-with-values
-				(lambda ()
-				  (random-multi-index inner-domain))
-			      (lambda inner-multi-index
-				(let ((new-element
-				       (random-array-element)))
-				  (apply inner-setter new-element inner-multi-index)
-				  ;; mutate the copied array without currying
-				  (apply (array-setter copied-array) new-element (append outer-multi-index inner-multi-index)))))))))))
-		(list mutable-curry
-		      specialized-curry
-		      mutable-curry-from-definition
-		      specialized-curry-from-definition
-		      ))
+                  (let ((outer-getter
+                         (array-getter curried-array)))
+                    (do ((i 0 (+ i 1)))
+                        ((= i 50))  ;; used to be tests, not 50, but 50 will do fine
+                      (call-with-values
+                          (lambda ()
+                            (random-multi-index outer-domain))
+                        (lambda outer-multi-index
+                          (let ((inner-setter
+                                 (array-setter (apply outer-getter outer-multi-index))))
+                            (call-with-values
+                                (lambda ()
+                                  (random-multi-index inner-domain))
+                              (lambda inner-multi-index
+                                (let ((new-element
+                                       (random-array-element)))
+                                  (apply inner-setter new-element inner-multi-index)
+                                  ;; mutate the copied array without currying
+                                  (apply (array-setter copied-array) new-element (append outer-multi-index inner-multi-index)))))))))))
+                (list mutable-curry
+                      specialized-curry
+                      mutable-curry-from-definition
+                      specialized-curry-from-definition
+                      ))
 
       (and (or (myarray= Array copied-array) (error "Arggh"))
-	   (or (array-every array? immutable-curry) (error "Arggh"))
-	   (or (array-every (lambda (a) (not (mutable-array? a))) immutable-curry) (error "Arggh"))
-	   (or (array-every mutable-array? mutable-curry) (error "Arggh"))
-	   (or (array-every (lambda (a) (not (specialized-array? a))) mutable-curry) (error "Arggh"))
-	   (or (array-every specialized-array? specialized-curry) (error "Arggh"))
-	   (or (array-every (lambda (xy) (apply myarray= xy))
+           (or (array-every array? immutable-curry) (error "Arggh"))
+           (or (array-every (lambda (a) (not (mutable-array? a))) immutable-curry) (error "Arggh"))
+           (or (array-every mutable-array? mutable-curry) (error "Arggh"))
+           (or (array-every (lambda (a) (not (specialized-array? a))) mutable-curry) (error "Arggh"))
+           (or (array-every specialized-array? specialized-curry) (error "Arggh"))
+           (or (array-every (lambda (xy) (apply myarray= xy))
                             (array-map list immutable-curry immutable-curry-from-definition))
-	       (error "Arggh"))
-	   (or (array-every (lambda (xy) (apply myarray= xy))
+               (error "Arggh"))
+           (or (array-every (lambda (xy) (apply myarray= xy))
                             (array-map list mutable-curry mutable-curry-from-definition))
-	       (error "Arggh"))
-	   (or (array-every (lambda (xy) (apply myarray= xy))
+               (error "Arggh"))
+           (or (array-every (lambda (xy) (apply myarray= xy))
                             (array-map list specialized-curry specialized-curry-from-definition))
-	       (error "Arggh"))))))
+               (error "Arggh"))))))
 
 
 
@@ -1659,22 +1659,22 @@
       "specialized-array-share: The first argument is not a specialized-array: ")
 
 (test (specialized-array-share (make-specialized-array (make-interval '#(1) '#(2)))
-			       1 1)
+                               1 1)
       "specialized-array-share: The second argument is not an interval: ")
 
 (test (specialized-array-share (make-specialized-array (make-interval '#(1) '#(2)))
-			       (make-interval '#(0) '#(1))
-			       1)
+                               (make-interval '#(0) '#(1))
+                               1)
       "specialized-array-share: The third argument is not a procedure: ")
 
 
 (test (myarray= (list->specialized-array (reverse (local-iota 0 10))
-					 (make-interval '#(0) '#(10)))
-		(specialized-array-share (list->specialized-array (local-iota 0 10)
-								  (make-interval '#(0) '#(10)))
-					 (make-interval '#(0) '#(10))
-					 (lambda (i)
-					   (- 9 i))))
+                                         (make-interval '#(0) '#(10)))
+                (specialized-array-share (list->specialized-array (local-iota 0 10)
+                                                                  (make-interval '#(0) '#(10)))
+                                         (make-interval '#(0) '#(10))
+                                         (lambda (i)
+                                           (- 9 i))))
       #t)
 
 
@@ -1683,12 +1683,12 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((n (random 1 11))
-	 (permutation (random-permutation n))
-	 (input-vec (list->vector (f64vector->list (random-f64vector n)))))
+         (permutation (random-permutation n))
+         (input-vec (list->vector (f64vector->list (random-f64vector n)))))
     (test (vector-permute input-vec permutation)
-	  (%%vector-permute input-vec permutation))
+          (%%vector-permute input-vec permutation))
     (test (list->vector (%%vector-permute->list input-vec permutation))
-	  (vector-permute input-vec permutation))))
+          (vector-permute input-vec permutation))))
 
 
 
@@ -1697,102 +1697,102 @@
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((axes (local-iota 0 (random 1 5)))
-	 (lower-bounds (list->vector (map (lambda (x) (random -10 10)) axes)))
-	 (upper-bounds (list->vector (map (lambda (l) (+ l (random 1 4))) (vector->list lower-bounds))))
-	 (a (array->specialized-array (make-array (make-interval lower-bounds
-								 upper-bounds)
-						  list)
-				      generic-storage-class
-				      ))
-	 (new-axis-order (vector-permute (list->vector axes) (random-permutation (length axes))))
-	 (reverse-order? (list->vector (map (lambda (x) (zero? (random 2))) axes))))
+         (lower-bounds (list->vector (map (lambda (x) (random -10 10)) axes)))
+         (upper-bounds (list->vector (map (lambda (l) (+ l (random 1 4))) (vector->list lower-bounds))))
+         (a (array->specialized-array (make-array (make-interval lower-bounds
+                                                                 upper-bounds)
+                                                  list)
+                                      generic-storage-class
+                                      ))
+         (new-axis-order (vector-permute (list->vector axes) (random-permutation (length axes))))
+         (reverse-order? (list->vector (map (lambda (x) (zero? (random 2))) axes))))
     (let ((b (make-array (make-interval (vector-permute lower-bounds new-axis-order)
-					(vector-permute upper-bounds new-axis-order))
-			 (lambda multi-index
-			   (apply (array-getter a)
-				  (let* ((n (vector-length new-axis-order))
-					 (multi-index-vector (list->vector multi-index))
-					 (result (make-vector n)))
-				    (do ((i 0 (+ i 1)))
-					((= i n) (vector->list result))
-				      (vector-set! result (vector-ref new-axis-order i)
-						   (if (vector-ref reverse-order? (vector-ref new-axis-order i))
-						       (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
-							  (- (vector-ref upper-bounds (vector-ref new-axis-order i))
-							     (vector-ref multi-index-vector i)
-							     1))
-						       (vector-ref multi-index-vector i)))))))))
-	  (c (specialized-array-share a
-				      (make-interval (vector-permute lower-bounds new-axis-order)
-						     (vector-permute upper-bounds new-axis-order))
-				      (lambda multi-index
-					(apply values
-					       (let* ((n (vector-length new-axis-order))
-						      (multi-index-vector (list->vector multi-index))
-						      (result (make-vector n)))
-						 (do ((i 0 (+ i 1)))
-						     ((= i n) (vector->list result))
-						   (vector-set! result (vector-ref new-axis-order i)
-								(if (vector-ref reverse-order? (vector-ref new-axis-order i))
-								    (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
-								       (- (vector-ref upper-bounds (vector-ref new-axis-order i))
-									  (vector-ref multi-index-vector i)
-									  1))
-								    (vector-ref multi-index-vector i))))))))))
+                                        (vector-permute upper-bounds new-axis-order))
+                         (lambda multi-index
+                           (apply (array-getter a)
+                                  (let* ((n (vector-length new-axis-order))
+                                         (multi-index-vector (list->vector multi-index))
+                                         (result (make-vector n)))
+                                    (do ((i 0 (+ i 1)))
+                                        ((= i n) (vector->list result))
+                                      (vector-set! result (vector-ref new-axis-order i)
+                                                   (if (vector-ref reverse-order? (vector-ref new-axis-order i))
+                                                       (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
+                                                          (- (vector-ref upper-bounds (vector-ref new-axis-order i))
+                                                             (vector-ref multi-index-vector i)
+                                                             1))
+                                                       (vector-ref multi-index-vector i)))))))))
+          (c (specialized-array-share a
+                                      (make-interval (vector-permute lower-bounds new-axis-order)
+                                                     (vector-permute upper-bounds new-axis-order))
+                                      (lambda multi-index
+                                        (apply values
+                                               (let* ((n (vector-length new-axis-order))
+                                                      (multi-index-vector (list->vector multi-index))
+                                                      (result (make-vector n)))
+                                                 (do ((i 0 (+ i 1)))
+                                                     ((= i n) (vector->list result))
+                                                   (vector-set! result (vector-ref new-axis-order i)
+                                                                (if (vector-ref reverse-order? (vector-ref new-axis-order i))
+                                                                    (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
+                                                                       (- (vector-ref upper-bounds (vector-ref new-axis-order i))
+                                                                          (vector-ref multi-index-vector i)
+                                                                          1))
+                                                                    (vector-ref multi-index-vector i))))))))))
       (if (not (myarray= b c))
-	  (pp (list "piffle"
-		    a b c))))))
+          (pp (list "piffle"
+                    a b c))))))
 
 (specialized-array-default-safe? #f)
 
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((axes (local-iota 0 (random 1 5)))
-	 (lower-bounds (list->vector (map (lambda (x) (random -10 10)) axes)))
-	 (upper-bounds (list->vector (map (lambda (l) (+ l (random 1 4))) (vector->list lower-bounds))))
-	 (a (array->specialized-array (make-array (make-interval lower-bounds
-								 upper-bounds)
-						  list)
-				      generic-storage-class
-				      ))
-	 (new-axis-order (vector-permute (list->vector axes) (random-permutation (length axes))))
-	 (reverse-order? (list->vector (map (lambda (x) (zero? (random 2))) axes))))
+         (lower-bounds (list->vector (map (lambda (x) (random -10 10)) axes)))
+         (upper-bounds (list->vector (map (lambda (l) (+ l (random 1 4))) (vector->list lower-bounds))))
+         (a (array->specialized-array (make-array (make-interval lower-bounds
+                                                                 upper-bounds)
+                                                  list)
+                                      generic-storage-class
+                                      ))
+         (new-axis-order (vector-permute (list->vector axes) (random-permutation (length axes))))
+         (reverse-order? (list->vector (map (lambda (x) (zero? (random 2))) axes))))
     (let ((b (make-array (make-interval (vector-permute lower-bounds new-axis-order)
-					(vector-permute upper-bounds new-axis-order))
-			 (lambda multi-index
-			   (apply (array-getter a)
-				  (let* ((n (vector-length new-axis-order))
-					 (multi-index-vector (list->vector multi-index))
-					 (result (make-vector n)))
-				    (do ((i 0 (+ i 1)))
-					((= i n) (vector->list result))
-				      (vector-set! result (vector-ref new-axis-order i)
-						   (if (vector-ref reverse-order? (vector-ref new-axis-order i))
-						       (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
-							  (- (vector-ref upper-bounds (vector-ref new-axis-order i))
-							     (vector-ref multi-index-vector i)
-							     1))
-						       (vector-ref multi-index-vector i)))))))))
-	  (c (specialized-array-share a
-				      (make-interval (vector-permute lower-bounds new-axis-order)
-						     (vector-permute upper-bounds new-axis-order))
-				      (lambda multi-index
-					(apply values
-					       (let* ((n (vector-length new-axis-order))
-						      (multi-index-vector (list->vector multi-index))
-						      (result (make-vector n)))
-						 (do ((i 0 (+ i 1)))
-						     ((= i n) (vector->list result))
-						   (vector-set! result (vector-ref new-axis-order i)
-								(if (vector-ref reverse-order? (vector-ref new-axis-order i))
-								    (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
-								       (- (vector-ref upper-bounds (vector-ref new-axis-order i))
-									  (vector-ref multi-index-vector i)
-									  1))
-								    (vector-ref multi-index-vector i))))))))))
+                                        (vector-permute upper-bounds new-axis-order))
+                         (lambda multi-index
+                           (apply (array-getter a)
+                                  (let* ((n (vector-length new-axis-order))
+                                         (multi-index-vector (list->vector multi-index))
+                                         (result (make-vector n)))
+                                    (do ((i 0 (+ i 1)))
+                                        ((= i n) (vector->list result))
+                                      (vector-set! result (vector-ref new-axis-order i)
+                                                   (if (vector-ref reverse-order? (vector-ref new-axis-order i))
+                                                       (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
+                                                          (- (vector-ref upper-bounds (vector-ref new-axis-order i))
+                                                             (vector-ref multi-index-vector i)
+                                                             1))
+                                                       (vector-ref multi-index-vector i)))))))))
+          (c (specialized-array-share a
+                                      (make-interval (vector-permute lower-bounds new-axis-order)
+                                                     (vector-permute upper-bounds new-axis-order))
+                                      (lambda multi-index
+                                        (apply values
+                                               (let* ((n (vector-length new-axis-order))
+                                                      (multi-index-vector (list->vector multi-index))
+                                                      (result (make-vector n)))
+                                                 (do ((i 0 (+ i 1)))
+                                                     ((= i n) (vector->list result))
+                                                   (vector-set! result (vector-ref new-axis-order i)
+                                                                (if (vector-ref reverse-order? (vector-ref new-axis-order i))
+                                                                    (+ (vector-ref lower-bounds (vector-ref new-axis-order i))
+                                                                       (- (vector-ref upper-bounds (vector-ref new-axis-order i))
+                                                                          (vector-ref multi-index-vector i)
+                                                                          1))
+                                                                    (vector-ref multi-index-vector i))))))))))
       (if (not (myarray= b c))
-	  (pp (list "piffle"
-		    a b c))))))
+          (pp (list "piffle"
+                    a b c))))))
 
 
 (pp "interval and array translation tests")
@@ -1800,114 +1800,114 @@
 (let ((int (make-interval '#(0 0) '#(10 10)))
       (translation '#(10 -2)))
   (test (interval-translate 'a 10)
-	"interval-translate: The first argument is not an interval: ")
+        "interval-translate: The first argument is not an interval: ")
   (test (interval-translate int 10)
-	"interval-translate: The second argument is not a vector of exact integers: ")
+        "interval-translate: The second argument is not a vector of exact integers: ")
   (test (interval-translate int '#(a b))
-	"interval-translate: The second argument is not a vector of exact integers: ")
+        "interval-translate: The second argument is not a vector of exact integers: ")
   (test (interval-translate int '#(1. 2.))
-	"interval-translate: The second argument is not a vector of exact integers: ")
+        "interval-translate: The second argument is not a vector of exact integers: ")
   (test (interval-translate int '#(1))
-	"interval-translate: The dimension of the first argument (an interval) does not equal the length of the second (a vector): ")
+        "interval-translate: The dimension of the first argument (an interval) does not equal the length of the second (a vector): ")
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((int (random-interval))
-	   (lower-bounds (interval-lower-bounds->vector int))
-	   (upper-bounds (interval-upper-bounds->vector int))
-	   (translation (list->vector (map (lambda (x)
-					     (random -10 10))
-					   (local-iota 0 (vector-length lower-bounds))))))
+           (lower-bounds (interval-lower-bounds->vector int))
+           (upper-bounds (interval-upper-bounds->vector int))
+           (translation (list->vector (map (lambda (x)
+                                             (random -10 10))
+                                           (local-iota 0 (vector-length lower-bounds))))))
       (interval= (interval-translate int translation)
-		 (make-interval (vector-map + lower-bounds translation)
-				(vector-map + upper-bounds translation))))))
+                 (make-interval (vector-map + lower-bounds translation)
+                                (vector-map + upper-bounds translation))))))
 
 (let* ((specialized-array (array->specialized-array (make-array (make-interval '#(0 0) '#(10 12))
-								list)))
+                                                                list)))
        (mutable-array (let ((temp (array->specialized-array specialized-array)))
-			(make-array (array-domain temp)
-				    (array-getter temp)
-				    (array-setter temp))))
+                        (make-array (array-domain temp)
+                                    (array-getter temp)
+                                    (array-setter temp))))
        (immutable-array (make-array (array-domain mutable-array)
-				    (array-getter mutable-array)))
+                                    (array-getter mutable-array)))
        (translation '#(10 -2)))
 
   (define (my-array-translate Array translation)
     (let* ((array-copy (array->specialized-array Array))
-	   (getter (array-getter array-copy))
-	   (setter (array-setter array-copy)))
+           (getter (array-getter array-copy))
+           (setter (array-setter array-copy)))
       (make-array (interval-translate (array-domain Array)
-				      translation)
-		  (lambda args
-		    (apply getter
-			   (map - args (vector->list translation))))
-		  (lambda (v . args)
-		    (apply setter
-			   v
-			   (map - args (vector->list translation)))))))
+                                      translation)
+                  (lambda args
+                    (apply getter
+                           (map - args (vector->list translation))))
+                  (lambda (v . args)
+                    (apply setter
+                           v
+                           (map - args (vector->list translation)))))))
 
   (test (array-translate 'a 1)
-	"array-translate: The first argument is not an array: ")
+        "array-translate: The first argument is not an array: ")
   (test (array-translate immutable-array '#(1.))
-	"array-translate: The second argument is not a vector of exact integers: ")
+        "array-translate: The second argument is not a vector of exact integers: ")
   (test (array-translate immutable-array '#(0 2 3))
-	"array-translate: The dimension of the first argument (an array) does not equal the dimension of the second argument (a vector): ")
+        "array-translate: The dimension of the first argument (an array) does not equal the dimension of the second argument (a vector): ")
   (let ((specialized-result (array-translate specialized-array translation)))
     (test (specialized-array? specialized-result)
-	  #t))
+          #t))
   (let ((mutable-result (array-translate mutable-array translation)))
     (test (and (mutable-array? mutable-array)
-	       (not (specialized-array? mutable-array))
-	       (mutable-array? mutable-result)
-	       (not (specialized-array? mutable-result)))
-	  #t))
+               (not (specialized-array? mutable-array))
+               (mutable-array? mutable-result)
+               (not (specialized-array? mutable-result)))
+          #t))
   (let ((immutable-result (array-translate immutable-array translation)))
     (test (and (array? immutable-array)
-	       (not (mutable-array? immutable-array))
-	       (array? immutable-result)
-	       (not (mutable-array? immutable-result)))
-	  #t))
+               (not (mutable-array? immutable-array))
+               (array? immutable-result)
+               (not (mutable-array? immutable-result)))
+          #t))
 
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((domain (random-interval 1 6))
-	   (Array (let ((temp (make-array domain list)))
-		    (case (random-integer 3)
-		      ((0) temp)
-		      ((1) (array->specialized-array temp))
-		      ((2) (let ((temp (array->specialized-array temp)))
-			     (make-array (array-domain temp)
-					 (array-getter temp)
-					 (array-setter temp)))))))
-	   (translation (list->vector (map (lambda (x) (random -10 10)) (vector->list (%%interval-lower-bounds domain))))))
+           (Array (let ((temp (make-array domain list)))
+                    (case (random-integer 3)
+                      ((0) temp)
+                      ((1) (array->specialized-array temp))
+                      ((2) (let ((temp (array->specialized-array temp)))
+                             (make-array (array-domain temp)
+                                         (array-getter temp)
+                                         (array-setter temp)))))))
+           (translation (list->vector (map (lambda (x) (random -10 10)) (vector->list (%%interval-lower-bounds domain))))))
       ;;(pp (list domain translation (interval-volume domain)))
       (let ((translated-array       (array-translate Array translation))
-	    (my-translated-array (my-array-translate Array translation)))
-	(if (mutable-array? Array)
-	    (let ((translated-domain (interval-translate domain translation)))
-	      (do ((j 0 (+ j 1)))
-		  ((= j 50))
-		(call-with-values
-		    (lambda ()
-		      (random-multi-index translated-domain))
-		  (lambda multi-index
-		    (let ((value (random-integer 10000)))
-		      (apply (array-setter translated-array) value multi-index)
-		      (apply (array-setter my-translated-array) value multi-index)))))))
-	(test (myarray= (array-translate Array translation)
-			(my-array-translate Array translation))
-	      #t)))))
+            (my-translated-array (my-array-translate Array translation)))
+        (if (mutable-array? Array)
+            (let ((translated-domain (interval-translate domain translation)))
+              (do ((j 0 (+ j 1)))
+                  ((= j 50))
+                (call-with-values
+                    (lambda ()
+                      (random-multi-index translated-domain))
+                  (lambda multi-index
+                    (let ((value (random-integer 10000)))
+                      (apply (array-setter translated-array) value multi-index)
+                      (apply (array-setter my-translated-array) value multi-index)))))))
+        (test (myarray= (array-translate Array translation)
+                        (my-array-translate Array translation))
+              #t)))))
 
 (let* ((specialized (make-specialized-array (make-interval '#(0 0 0 0 0) '#(1 1 1 1 1))))
        (mutable (make-array (array-domain specialized)
-			    (array-getter specialized)
-			    (array-setter specialized)))
+                            (array-getter specialized)
+                            (array-setter specialized)))
        (A (array-translate  mutable '#(0 0 0 0 0))))
 
   (test ((array-getter A) 0 0)
-	"The number of indices does not equal the array dimension: ")
+        "The number of indices does not equal the array dimension: ")
 
   (test ((array-setter A) 'a 0 0)
-	"The number of indices does not equal the array dimension: "))
+        "The number of indices does not equal the array dimension: "))
 
 
 (pp "interval and array permutation tests")
@@ -1915,174 +1915,174 @@
 (let ((int (make-interval '#(0 0) '#(10 10)))
       (permutation '#(1 0)))
   (test (interval-permute 'a 10)
-	"interval-permute: The first argument is not an interval: ")
+        "interval-permute: The first argument is not an interval: ")
   (test (interval-permute int 10)
-	"interval-permute: The second argument is not a permutation: ")
+        "interval-permute: The second argument is not a permutation: ")
   (test (interval-permute int '#(a b))
-	"interval-permute: The second argument is not a permutation: ")
+        "interval-permute: The second argument is not a permutation: ")
   (test (interval-permute int '#(1. 2.))
-	"interval-permute: The second argument is not a permutation: ")
+        "interval-permute: The second argument is not a permutation: ")
   (test (interval-permute int '#(10 -2))
-	"interval-permute: The second argument is not a permutation: ")
+        "interval-permute: The second argument is not a permutation: ")
   (test (interval-permute int '#(0))
-	"interval-permute: The dimension of the first argument (an interval) does not equal the length of the second (a permutation): ")
+        "interval-permute: The dimension of the first argument (an interval) does not equal the length of the second (a permutation): ")
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((int (random-interval))
-	   (lower-bounds (interval-lower-bounds->vector int))
-	   (upper-bounds (interval-upper-bounds->vector int))
-	   (permutation (random-permutation (vector-length lower-bounds))))
+           (lower-bounds (interval-lower-bounds->vector int))
+           (upper-bounds (interval-upper-bounds->vector int))
+           (permutation (random-permutation (vector-length lower-bounds))))
       (interval= (interval-permute int permutation)
-		 (make-interval (vector-permute lower-bounds permutation)
-				(vector-permute upper-bounds permutation))))))
+                 (make-interval (vector-permute lower-bounds permutation)
+                                (vector-permute upper-bounds permutation))))))
 
 (let* ((specialized-array (array->specialized-array (make-array (make-interval '#(0 0) '#(10 12))
-								list)))
+                                                                list)))
        (mutable-array (let ((temp (array->specialized-array specialized-array)))
-			(make-array (array-domain temp)
-				    (array-getter temp)
-				    (array-setter temp))))
+                        (make-array (array-domain temp)
+                                    (array-getter temp)
+                                    (array-setter temp))))
        (immutable-array (make-array (array-domain mutable-array)
-				    (array-getter mutable-array)))
+                                    (array-getter mutable-array)))
        (permutation '#(1 0)))
 
   (test (array-permute 'a 1)
-	"array-permute: The first argument is not an array: ")
+        "array-permute: The first argument is not an array: ")
   (test (array-permute immutable-array '#(1.))
-	"array-permute: The second argument is not a permutation: ")
+        "array-permute: The second argument is not a permutation: ")
   (test (array-permute immutable-array '#(2))
-	"array-permute: The second argument is not a permutation: ")
+        "array-permute: The second argument is not a permutation: ")
   (test (array-permute immutable-array '#(0 1 2))
-	"array-permute: The dimension of the first argument (an array) does not equal the dimension of the second argument (a permutation): ")
+        "array-permute: The dimension of the first argument (an array) does not equal the dimension of the second argument (a permutation): ")
   (let ((specialized-result (array-permute specialized-array permutation)))
     (test (specialized-array? specialized-result)
-	  #t))
+          #t))
   (let ((mutable-result (array-permute mutable-array permutation)))
     (test (and (mutable-array? mutable-array)
-	       (not (specialized-array? mutable-array))
-	       (mutable-array? mutable-result)
-	       (not (specialized-array? mutable-result)))
-	  #t))
+               (not (specialized-array? mutable-array))
+               (mutable-array? mutable-result)
+               (not (specialized-array? mutable-result)))
+          #t))
   (let ((immutable-result (array-permute immutable-array permutation)))
     (test (and (array? immutable-array)
-	       (not (mutable-array? immutable-array))
-	       (array? immutable-result)
-	       (not (mutable-array? immutable-result)))
-	  #t))
+               (not (mutable-array? immutable-array))
+               (array? immutable-result)
+               (not (mutable-array? immutable-result)))
+          #t))
 
   (specialized-array-default-safe? #t)
 
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((domain (random-interval 1 6))
-	   (Array (let ((temp (make-array domain list)))
-		    (case (random-integer 3)
-		      ((0) temp)
-		      ((1) (array->specialized-array temp))
-		      ((2) (let ((temp (array->specialized-array temp)))
-			     (make-array (array-domain temp)
-					 (array-getter temp)
-					 (array-setter temp)))))))
-	   (permutation (random-permutation (interval-dimension domain))))
+           (Array (let ((temp (make-array domain list)))
+                    (case (random-integer 3)
+                      ((0) temp)
+                      ((1) (array->specialized-array temp))
+                      ((2) (let ((temp (array->specialized-array temp)))
+                             (make-array (array-domain temp)
+                                         (array-getter temp)
+                                         (array-setter temp)))))))
+           (permutation (random-permutation (interval-dimension domain))))
 
       (define (my-array-permute Array permutation)
-	(let* ((array-copy (array->specialized-array Array))
-	       (getter (array-getter array-copy))
-	       (setter (array-setter array-copy))
-	       (permutation-inverse (%%permutation-invert permutation)))
-	  (make-array (interval-permute (array-domain Array)
-					permutation)
-		      (lambda args
-			(apply getter
-			       (vector->list (vector-permute (list->vector args) permutation-inverse))))
-		      (lambda (v . args)
-			(apply setter
-			       v
-			       (vector->list (vector-permute (list->vector args) permutation-inverse)))))))
+        (let* ((array-copy (array->specialized-array Array))
+               (getter (array-getter array-copy))
+               (setter (array-setter array-copy))
+               (permutation-inverse (%%permutation-invert permutation)))
+          (make-array (interval-permute (array-domain Array)
+                                        permutation)
+                      (lambda args
+                        (apply getter
+                               (vector->list (vector-permute (list->vector args) permutation-inverse))))
+                      (lambda (v . args)
+                        (apply setter
+                               v
+                               (vector->list (vector-permute (list->vector args) permutation-inverse)))))))
 
       ;; (pp (list domain permutation (interval-volume domain)))
       (let ((permuted-array       (array-permute Array permutation))
-	    (my-permuted-array (my-array-permute Array permutation)))
-	(let ((permuted-domain (interval-permute domain permutation)))
-	  (do ((j 0 (+ j 1)))
-	      ((= j 50))
-	    (call-with-values
-		(lambda ()
-		  (random-multi-index permuted-domain))
-	      (lambda multi-index
-		(test (apply (array-getter permuted-array)    multi-index)
-		      (apply (array-getter my-permuted-array) multi-index))))))
-	(if (mutable-array? Array)
-	    (let ((permuted-domain (interval-permute domain permutation)))
-	      (do ((j 0 (+ j 1)))
-		  ((= j 50))
-		(call-with-values
-		    (lambda ()
-		      (random-multi-index permuted-domain))
-		  (lambda multi-index
-		    (let ((value (random-integer 10000)))
-		      (apply (array-setter permuted-array) value multi-index)
-		      (apply (array-setter my-permuted-array) value multi-index)))))))
-	(test (myarray= permuted-array
-			my-permuted-array)
-	      #t))))
+            (my-permuted-array (my-array-permute Array permutation)))
+        (let ((permuted-domain (interval-permute domain permutation)))
+          (do ((j 0 (+ j 1)))
+              ((= j 50))
+            (call-with-values
+                (lambda ()
+                  (random-multi-index permuted-domain))
+              (lambda multi-index
+                (test (apply (array-getter permuted-array)    multi-index)
+                      (apply (array-getter my-permuted-array) multi-index))))))
+        (if (mutable-array? Array)
+            (let ((permuted-domain (interval-permute domain permutation)))
+              (do ((j 0 (+ j 1)))
+                  ((= j 50))
+                (call-with-values
+                    (lambda ()
+                      (random-multi-index permuted-domain))
+                  (lambda multi-index
+                    (let ((value (random-integer 10000)))
+                      (apply (array-setter permuted-array) value multi-index)
+                      (apply (array-setter my-permuted-array) value multi-index)))))))
+        (test (myarray= permuted-array
+                        my-permuted-array)
+              #t))))
 
   (specialized-array-default-safe? #f)
 
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((domain (random-interval 1 6))
-	   (Array (let ((temp (make-array domain list)))
-		    (case (random-integer 3)
-		      ((0) temp)
-		      ((1) (array->specialized-array temp))
-		      ((2) (let ((temp (array->specialized-array temp)))
-			     (make-array (array-domain temp)
-					 (array-getter temp)
-					 (array-setter temp)))))))
-	   (permutation (random-permutation (interval-dimension domain))))
+           (Array (let ((temp (make-array domain list)))
+                    (case (random-integer 3)
+                      ((0) temp)
+                      ((1) (array->specialized-array temp))
+                      ((2) (let ((temp (array->specialized-array temp)))
+                             (make-array (array-domain temp)
+                                         (array-getter temp)
+                                         (array-setter temp)))))))
+           (permutation (random-permutation (interval-dimension domain))))
 
       (define (my-array-permute Array permutation)
-	(let* ((array-copy (array->specialized-array Array))
-	       (getter (array-getter array-copy))
-	       (setter (array-setter array-copy))
-	       (permutation-inverse (%%permutation-invert permutation)))
-	  (make-array (interval-permute (array-domain Array)
-					permutation)
-		      (lambda args
-			(apply getter
-			       (vector->list (vector-permute (list->vector args) permutation-inverse))))
-		      (lambda (v . args)
-			(apply setter
-			       v
-			       (vector->list (vector-permute (list->vector args) permutation-inverse)))))))
+        (let* ((array-copy (array->specialized-array Array))
+               (getter (array-getter array-copy))
+               (setter (array-setter array-copy))
+               (permutation-inverse (%%permutation-invert permutation)))
+          (make-array (interval-permute (array-domain Array)
+                                        permutation)
+                      (lambda args
+                        (apply getter
+                               (vector->list (vector-permute (list->vector args) permutation-inverse))))
+                      (lambda (v . args)
+                        (apply setter
+                               v
+                               (vector->list (vector-permute (list->vector args) permutation-inverse)))))))
 
       ;; (pp (list domain permutation (interval-volume domain)))
       (let ((permuted-array       (array-permute Array permutation))
-	    (my-permuted-array (my-array-permute Array permutation)))
-	(let ((permuted-domain (interval-permute domain permutation)))
-	  (do ((j 0 (+ j 1)))
-	      ((= j 50))
-	    (call-with-values
-		(lambda ()
-		  (random-multi-index permuted-domain))
-	      (lambda multi-index
-		(test (apply (array-getter permuted-array)    multi-index)
-		      (apply (array-getter my-permuted-array) multi-index))))))
-	(if (mutable-array? Array)
-	    (let ((permuted-domain (interval-permute domain permutation)))
-	      (do ((j 0 (+ j 1)))
-		  ((= j 50))
-		(call-with-values
-		    (lambda ()
-		      (random-multi-index permuted-domain))
-		  (lambda multi-index
-		    (let ((value (random-integer 10000)))
-		      (apply (array-setter permuted-array) value multi-index)
-		      (apply (array-setter my-permuted-array) value multi-index)))))))
-	(test (myarray= permuted-array
-			my-permuted-array)
-	      #t))))
+            (my-permuted-array (my-array-permute Array permutation)))
+        (let ((permuted-domain (interval-permute domain permutation)))
+          (do ((j 0 (+ j 1)))
+              ((= j 50))
+            (call-with-values
+                (lambda ()
+                  (random-multi-index permuted-domain))
+              (lambda multi-index
+                (test (apply (array-getter permuted-array)    multi-index)
+                      (apply (array-getter my-permuted-array) multi-index))))))
+        (if (mutable-array? Array)
+            (let ((permuted-domain (interval-permute domain permutation)))
+              (do ((j 0 (+ j 1)))
+                  ((= j 50))
+                (call-with-values
+                    (lambda ()
+                      (random-multi-index permuted-domain))
+                  (lambda multi-index
+                    (let ((value (random-integer 10000)))
+                      (apply (array-setter permuted-array) value multi-index)
+                      (apply (array-setter my-permuted-array) value multi-index)))))))
+        (test (myarray= permuted-array
+                        my-permuted-array)
+              #t))))
   )
 
 (pp "array-rotate  and interval-rotate tests")
@@ -2181,50 +2181,50 @@
       (b (make-interval '#(0) '#(10)))
       (c (make-interval '#(10 10) '#(20 20))))
   (test (interval-intersect 'a)
-	"interval-intersect: The argument is not an interval: ")
+        "interval-intersect: The argument is not an interval: ")
   (test (interval-intersect  a 'a)
-	"interval-intersect: Not all arguments are intervals: ")
+        "interval-intersect: Not all arguments are intervals: ")
   (test (interval-intersect a b)
-	"interval-intersect: Not all arguments have the same dimension: "))
+        "interval-intersect: Not all arguments have the same dimension: "))
 
 
 (define (my-interval-intersect . args)
 
   (define (fold-left operator           ;; called with (operator result-so-far (car list))
-		     initial-value
-		     list)
+                     initial-value
+                     list)
     (if (null? list)
-	initial-value
-	(fold-left operator
-		   (operator initial-value (car list))
-		   (cdr list))))
+        initial-value
+        (fold-left operator
+                   (operator initial-value (car list))
+                   (cdr list))))
 
 
   (let ((new-uppers (let ((uppers (map interval-upper-bounds->vector args)))
-		      (fold-left (lambda (arg result)
-				   (vector-map min arg result))
-				 (car uppers)
-				 uppers)))
-	(new-lowers (let ((lowers (map interval-lower-bounds->vector args)))
-		      (fold-left (lambda (arg result)
-				   (vector-map max arg result))
-				 (car lowers)
-				 lowers))))
+                      (fold-left (lambda (arg result)
+                                   (vector-map min arg result))
+                                 (car uppers)
+                                 uppers)))
+        (new-lowers (let ((lowers (map interval-lower-bounds->vector args)))
+                      (fold-left (lambda (arg result)
+                                   (vector-map max arg result))
+                                 (car lowers)
+                                 lowers))))
     ;; (pp (list args new-lowers new-uppers (vector-every < new-lowers new-uppers)))
     (and (%%vector-every < new-lowers new-uppers)
-	 (make-interval new-lowers new-uppers))))
+         (make-interval new-lowers new-uppers))))
 
 
 (do ((i 0 (+ i 1)))
     ((= i tests))
   (let* ((dimension (random 1 6))
-	 (number-of-intervals (random 1 4))
-	 (intervals (map (lambda (x)
-			   (random-interval dimension (+ dimension 1)))
-			 (local-iota 0 number-of-intervals))))
+         (number-of-intervals (random 1 4))
+         (intervals (map (lambda (x)
+                           (random-interval dimension (+ dimension 1)))
+                         (local-iota 0 number-of-intervals))))
     ;; (pp (list intervals (apply my-interval-intersect intervals)))
     (test (apply my-interval-intersect intervals)
-	  (apply interval-intersect intervals))))
+          (apply interval-intersect intervals))))
 
 (pp "test interval-scale and array-sample")
 
@@ -2763,8 +2763,8 @@
 (pp "Miscellaneous error tests")
 
 (test (make-array (make-interval '#(0 0) '#(10 10))
-		  list
-		  'a)
+                  list
+                  'a)
       "make-array: The third argument is not a procedure: ")
 
 (test (array-dimension 'a)
@@ -2778,56 +2778,56 @@
       #f)
 
 (let ((array-builders (vector (list u1-storage-class      (lambda indices (random (expt 2 1))) '(a -1))
-			      (list u8-storage-class      (lambda indices (random (expt 2 8))) '(a -1))
-			      (list u16-storage-class     (lambda indices (random (expt 2 16))) '(a -1))
-			      (list u32-storage-class     (lambda indices (random (expt 2 32))) '(a -1))
-			      (list u64-storage-class     (lambda indices (random (expt 2 64))) '(a -1))
-			      (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))) `(a ,(expt 2 8)))
-			      (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))) `(a ,(expt 2 16)))
-			      (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))) `(a ,(expt 2 32)))
-			      (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))) `(a ,(expt 2 64)))
-			      (list f32-storage-class     (lambda indices (random-real)) `(a 1))
-			      (list f64-storage-class     (lambda indices (random-real)) `(a 1))
+                              (list u8-storage-class      (lambda indices (random (expt 2 8))) '(a -1))
+                              (list u16-storage-class     (lambda indices (random (expt 2 16))) '(a -1))
+                              (list u32-storage-class     (lambda indices (random (expt 2 32))) '(a -1))
+                              (list u64-storage-class     (lambda indices (random (expt 2 64))) '(a -1))
+                              (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))) `(a ,(expt 2 8)))
+                              (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))) `(a ,(expt 2 16)))
+                              (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))) `(a ,(expt 2 32)))
+                              (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))) `(a ,(expt 2 64)))
+                              (list f32-storage-class     (lambda indices (random-real)) `(a 1))
+                              (list f64-storage-class     (lambda indices (random-real)) `(a 1))
                               (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))) `(a 1))
                               (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))) `(a 1))
-			      )))
+                              )))
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((domain (random-interval 1 6))
-	   (builders (vector-ref array-builders (random-integer (vector-length array-builders))))
-	   (storage-class (car builders))
-	   (random-entry (cadr builders))
-	   (invalid-entry (list-ref (caddr builders) (random 2)))
-	   (Array (array->specialized-array (make-array domain random-entry)
-					    storage-class
+           (builders (vector-ref array-builders (random-integer (vector-length array-builders))))
+           (storage-class (car builders))
+           (random-entry (cadr builders))
+           (invalid-entry (list-ref (caddr builders) (random 2)))
+           (Array (array->specialized-array (make-array domain random-entry)
+                                            storage-class
                                             #t   ; mutable
-					    #t)) ; safe
-	   (getter (array-getter Array))
-	   (setter (array-setter Array))
-	   (dimension (interval-dimension domain))
-	   (valid-args (call-with-values
-			   (lambda ()
-			     (random-multi-index domain))
-			 list)))
+                                            #t)) ; safe
+           (getter (array-getter Array))
+           (setter (array-setter Array))
+           (dimension (interval-dimension domain))
+           (valid-args (call-with-values
+                           (lambda ()
+                             (random-multi-index domain))
+                         list)))
       (test (apply setter invalid-entry valid-args)
-	    "array-setter: value cannot be stored in body: ")
+            "array-setter: value cannot be stored in body: ")
       (set-car! valid-args 'a)
       (test (apply getter valid-args)
-	    "array-getter: multi-index component is not an exact integer: ")
+            "array-getter: multi-index component is not an exact integer: ")
       (test (apply setter 10 valid-args)
-	    "array-setter: multi-index component is not an exact integer: ")
+            "array-setter: multi-index component is not an exact integer: ")
       (set-car! valid-args 10000) ;; outside the range of any random-interval
       (test (apply getter valid-args)
-	    "array-getter: domain does not contain multi-index: ")
+            "array-getter: domain does not contain multi-index: ")
       (test (apply setter 10 valid-args)
-	    "array-setter: domain does not contain multi-index: " )
+            "array-setter: domain does not contain multi-index: " )
       (if (< 4 dimension)
-	  (begin
-	    (set! valid-args (cons 1 valid-args))
-	    (test (apply getter valid-args)
-		  "array-getter: multi-index is not the correct dimension: ")
-	    (test (apply setter 10 valid-args)
-		  "array-setter: multi-index is not the correct dimension: "))))))
+          (begin
+            (set! valid-args (cons 1 valid-args))
+            (test (apply getter valid-args)
+                  "array-getter: multi-index is not the correct dimension: ")
+            (test (apply setter 10 valid-args)
+                  "array-setter: multi-index is not the correct dimension: "))))))
 
 (pp "array->list and list->specialized-array")
 
@@ -2859,32 +2859,32 @@
 
 
 (let ((array-builders (vector (list u1-storage-class      (lambda indices (random 0 (expt 2 1))))
-			      (list u8-storage-class      (lambda indices (random 0 (expt 2 8))))
-			      (list u16-storage-class     (lambda indices (random 0 (expt 2 16))))
-			      (list u32-storage-class     (lambda indices (random 0 (expt 2 32))))
-			      (list u64-storage-class     (lambda indices (random 0 (expt 2 64))))
-			      (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
-			      (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
-			      (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
-			      (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-			      (list f32-storage-class     (lambda indices (random-real)))
-			      (list f64-storage-class     (lambda indices (random-real)))
-			      (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
-			      (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
-			      (list generic-storage-class (lambda indices indices)))))
+                              (list u8-storage-class      (lambda indices (random 0 (expt 2 8))))
+                              (list u16-storage-class     (lambda indices (random 0 (expt 2 16))))
+                              (list u32-storage-class     (lambda indices (random 0 (expt 2 32))))
+                              (list u64-storage-class     (lambda indices (random 0 (expt 2 64))))
+                              (list s8-storage-class      (lambda indices (random (- (expt 2 7))  (expt 2 7))))
+                              (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
+                              (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
+                              (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
+                              (list f32-storage-class     (lambda indices (random-real)))
+                              (list f64-storage-class     (lambda indices (random-real)))
+                              (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
       ((= i tests))
     (let* ((domain (random-interval 1 6))
-	   (builders (vector-ref array-builders (random-integer (vector-length array-builders))))
-	   (storage-class (car builders))
-	   (random-entry (cadr builders))
-	   (Array (array->specialized-array (make-array domain random-entry)
-					    storage-class
-					    #t)) ; safe
-	   (l (array->list Array))
-	   (new-array (list->specialized-array l domain storage-class (zero? (random-integer 2)))))
+           (builders (vector-ref array-builders (random-integer (vector-length array-builders))))
+           (storage-class (car builders))
+           (random-entry (cadr builders))
+           (Array (array->specialized-array (make-array domain random-entry)
+                                            storage-class
+                                            #t)) ; safe
+           (l (array->list Array))
+           (new-array (list->specialized-array l domain storage-class (zero? (random-integer 2)))))
       (test (myarray= Array new-array)
-	    #t))))
+            #t))))
 
 (pp "interval-cartesian-product and array-outer-product")
 
@@ -2979,25 +2979,25 @@
 (pp "Test code from the SRFI document")
 
 (test (interval= (interval-dilate (make-interval '#(100 100)) '#(1 1) '#(1 1))
-		 (make-interval '#(1 1) '#(101 101)))
+                 (make-interval '#(1 1) '#(101 101)))
       #t)
 
 (test (interval= (interval-dilate (make-interval '#(100 100)) '#(-1 -1) '#(1 1))
-		 (make-interval '#(-1 -1) '#(101 101)))
+                 (make-interval '#(-1 -1) '#(101 101)))
       #t)
 
 (test (interval= (interval-dilate (make-interval '#(100 100))  '#(0 0) '#(-50 -50))
-		 (make-interval '#(50 50)))
+                 (make-interval '#(50 50)))
       #t)
 
 (test (interval-dilate (make-interval '#(100 100)) '#(0 0) '#(-500 -50))
       "interval-dilate: The resulting interval is empty: ")
 
 (define a (make-array (make-interval '#(1 1) '#(11 11))
-		      (lambda (i j)
-			(if (= i j)
-			    1
-			    0))))
+                      (lambda (i j)
+                        (if (= i j)
+                            1
+                            0))))
 
 (test ((array-getter a) 3 3)
       1)
@@ -3008,7 +3008,7 @@
 ;; ((array-getter a) 11 0) is an error, but it isn't signalled
 
 (define a (make-array (make-interval '#(0 0) '#(10 10))
-		      list))
+                      list))
 
 (test ((array-getter a) 3 4)
       '(3 4))
@@ -3020,19 +3020,19 @@
 
 (define sparse-array
   (let ((domain (make-interval '#(1000000 1000000)))
-	(sparse-rows (make-vector 1000000 '())))
+        (sparse-rows (make-vector 1000000 '())))
     (make-array domain
-		(lambda (i j)
-		  (cond ((assv j (vector-ref sparse-rows i))
-			 => cdr)
-			(else
-			 0.0)))
-		(lambda (v i j)
-		  (cond ((assv j (vector-ref sparse-rows i))
-			 => (lambda (pair)
-			      (set-cdr! pair v)))
-			(else
-			 (vector-set! sparse-rows i (cons (cons j v) (vector-ref sparse-rows i)))))))))
+                (lambda (i j)
+                  (cond ((assv j (vector-ref sparse-rows i))
+                         => cdr)
+                        (else
+                         0.0)))
+                (lambda (v i j)
+                  (cond ((assv j (vector-ref sparse-rows i))
+                         => (lambda (pair)
+                              (set-cdr! pair v)))
+                        (else
+                         (vector-set! sparse-rows i (cons (cons j v) (vector-ref sparse-rows i)))))))))
 
 (test ((array-getter sparse-array) 12345 6789)
       0.)
@@ -3112,13 +3112,13 @@
     (let ((o (read port)))
       (read-char port) ; to skip the newline or next whitespace
       (if (eof-object? o)
-	  (error "reached end of pgm file")
-	  o)))
+          (error "reached end of pgm file")
+          o)))
 
   (define (skip-to-end-of-line port)
     (let loop ((ch (read-char port)))
       (if (not (eq? ch #\newline))
-	  (loop (read-char port)))))
+          (loop (read-char port)))))
 
   (define (white-space? ch)
     (case ch
@@ -3128,35 +3128,35 @@
   (define (skip-white-space port)
     (let ((ch (peek-char port)))
       (cond ((white-space? ch) (read-char port) (skip-white-space port))
-	    ((eq? ch #\#) (skip-to-end-of-line port)(skip-white-space port))
-	    (else #f))))
+            ((eq? ch #\#) (skip-to-end-of-line port)(skip-white-space port))
+            (else #f))))
 
   (call-with-input-file
       file
     (lambda (port)
       (let* ((header (read-pgm-object port))
-	     (columns (read-pgm-object port))
-	     (rows (read-pgm-object port))
-	     (greys (read-pgm-object port)))
-	(make-pgm greys
-		  (array->specialized-array
-		   (make-array
-		    (make-interval (vector rows columns))
-		    (cond ((or (eq? header 'p5)                                     ;; pgm binary
-			       (eq? header 'P5))
-			   (if (< greys 256)
-			       (lambda (i j)                                        ;; one byte/pixel
-				 (char->integer (read-char port)))
-			       (lambda (i j)                                        ;; two bytes/pixel, little-endian
-				 (let* ((first-byte (char->integer (read-char port)))
-					(second-byte (char->integer (read-char port))))
-				   (+ (* second-byte 256) first-byte)))))
-			  ((or (eq? header 'p2)                                     ;; pgm ascii
-			       (eq? header 'P2))
-			   (lambda (i j)
-			     (read port)))
-			  (else
-			   (error "read-pgm: not a pgm file"))))))))))
+             (columns (read-pgm-object port))
+             (rows (read-pgm-object port))
+             (greys (read-pgm-object port)))
+        (make-pgm greys
+                  (array->specialized-array
+                   (make-array
+                    (make-interval (vector rows columns))
+                    (cond ((or (eq? header 'p5)                                     ;; pgm binary
+                               (eq? header 'P5))
+                           (if (< greys 256)
+                               (lambda (i j)                                        ;; one byte/pixel
+                                 (char->integer (read-char port)))
+                               (lambda (i j)                                        ;; two bytes/pixel, little-endian
+                                 (let* ((first-byte (char->integer (read-char port)))
+                                        (second-byte (char->integer (read-char port))))
+                                   (+ (* second-byte 256) first-byte)))))
+                          ((or (eq? header 'p2)                                     ;; pgm ascii
+                               (eq? header 'P2))
+                           (lambda (i j)
+                             (read port)))
+                          (else
+                           (error "read-pgm: not a pgm file"))))))))))
 
 (define (write-pgm pgm-data file #!optional force-ascii)
   (call-with-output-file
@@ -3164,24 +3164,24 @@
     (lambda (port)
       (let* ((greys
               (pgm-greys pgm-data))
-	     (pgm-array
+             (pgm-array
               (pgm-pixels pgm-data))
-	     (domain
+             (domain
               (array-domain pgm-array))
-	     (rows
+             (rows
               (fx- (interval-upper-bound domain 0)
                    (interval-lower-bound domain 0)))
-	     (columns
+             (columns
               (fx- (interval-upper-bound domain 1)
                    (interval-lower-bound domain 1))))
-	(if force-ascii
-	    (display "P2" port)
-	    (display "P5" port))
-	(newline port)
-	(display columns port) (display " " port)
-	(display rows port) (newline port)
-	(display greys port) (newline port)
-	(array-for-each (if force-ascii
+        (if force-ascii
+            (display "P2" port)
+            (display "P5" port))
+        (newline port)
+        (display columns port) (display " " port)
+        (display rows port) (newline port)
+        (display greys port) (newline port)
+        (array-for-each (if force-ascii
                             (let ((next-pixel-in-line 1))
                               (lambda (p)
                                 (write p port)
@@ -3397,14 +3397,14 @@ that computes the componentwise products when we need them, the times are
                (reverse result)))))))
 
 (define image (array->specialized-array (make-array (make-interval '#(8 8))
-						    (lambda (i j)
-						      (exact->inexact (+ (* i i) (* j j)))))))
+                                                    (lambda (i j)
+                                                      (exact->inexact (+ (* i i) (* j j)))))))
 
 (define (expose difference-images)
   (pretty-print (map (lambda (difference-image)
-		       (list (array-domain difference-image)
-			     (array->list difference-image)))
-		     difference-images)))
+                       (list (array-domain difference-image)
+                             (array->list difference-image)))
+                     difference-images)))
 (begin
   (display "\nSecond-difference images in the direction $k\\times (1,0)$, $k=1,2,...$, wherever they're defined:\n")
   (expose (all-second-differences image '#(1 0)))
@@ -3444,16 +3444,16 @@ that computes the componentwise products when we need them, the times are
 
 (define (1D-Haar-loop a)
   (let ((a_ (array-getter a))
-	(a! (array-setter a))
-	(n (interval-upper-bound (array-domain a) 0)))
+        (a! (array-setter a))
+        (n (interval-upper-bound (array-domain a) 0)))
     (do ((i 0 (fx+ i 2)))
-	((fx= i n))
+        ((fx= i n))
       (let* ((a_i               (a_ i))
-	     (a_i+1             (a_ (fx+ i 1)))
-	     (scaled-sum        (fl/ (fl+ a_i a_i+1) (flsqrt 2.0)))
-	     (scaled-difference (fl/ (fl- a_i a_i+1) (flsqrt 2.0))))
-	(a! scaled-sum i)
-	(a! scaled-difference (fx+ i 1))))))
+             (a_i+1             (a_ (fx+ i 1)))
+             (scaled-sum        (fl/ (fl+ a_i a_i+1) (flsqrt 2.0)))
+             (scaled-difference (fl/ (fl- a_i a_i+1) (flsqrt 2.0))))
+        (a! scaled-sum i)
+        (a! scaled-difference (fx+ i 1))))))
 
 (define 1D-Haar-transform
   (recursively-apply-transform-and-downsample 1D-Haar-loop))
@@ -3485,15 +3485,15 @@ that computes the componentwise products when we need them, the times are
                         (else 0.)))))))
   (display "\nInitial image: \n")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (hyperbolic-Haar-transform image)
   (display "\nArray of hyperbolic Haar wavelet coefficients: \n")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (hyperbolic-Haar-inverse-transform image)
   (display "\nReconstructed image: \n")
   (pretty-print (list (array-domain image)
-		      (array->list image))))
+                      (array->list image))))
 
 
 (let ((image
@@ -3506,15 +3506,15 @@ that computes the componentwise products when we need them, the times are
                         (else 0.)))))))
   (display "\nInitial image: \n")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (Haar-transform image)
   (display "\nArray of Haar wavelet coefficients: \n")
   (pretty-print (list (array-domain image)
-		      (array->list image)))
+                      (array->list image)))
   (Haar-inverse-transform image)
   (display "\nReconstructed image: \n")
   (pretty-print (list (array-domain image)
-		      (array->list image))))
+                      (array->list image))))
 
 (define (LU-decomposition A)
   ;; Assumes the domain of A is [0,n)\\times [0,n)


### PR DESCRIPTION
Big changes:

Replace `array->specialized-array` by `array-copy`, which is allowed to reshape arrays when copying.
Remove `array-swap!`.
Consolidate all code that moves elements of arrays.
Implement `array-ref` and `array-set!`.