### PR TITLE
Specify initial defaults, make random tests more consistent

### DIFF
--- a/srfi-179.html
+++ b/srfi-179.html
@@ -34,7 +34,8 @@
       <li>Revised to fix errata:
         <ul>
           <li>2020-10-08 (Fix documentation for <code>interval-subset?</code>.)</li>
-          <li>2021-02-24 (Correct the note comparing  <code>array-curry</code> and <code>array-tile</code>.)</li></ul></li>
+          <li>2021-02-24 (Correct the note comparing  <code>array-curry</code> and <code>array-tile</code>.)</li>
+          <li>2021-05-02 (Correct documentation of <code>interval-cartesian-product</code>; document initial values for <code>(specialized-array-default-safe?)</code> and <code>(specialized-array-default-mutable?)</code>.</li></ul></li>
       <li id="pfn1">Post-finalization note added on 2020-12-10: The document
         was updated to improve the examples and to explain the use of <code>array-copy</code> to
         improve efficiency in some situations.</li>
@@ -396,8 +397,8 @@
     <p><b>Procedure: </b><code><a id="interval-cartesian-product">interval-cartesian-product</a> <var>interval</var> . <var>intervals</var></code></p>
     <p>Implements the Cartesian product of the intervals in <code>(cons <var>interval</var> <var>intervals</var>)</code>. Returns</p>
     <pre><code>
-(make-interval (list-&gt;vector (apply append (map array-lower-bounds-&gt;list (cons interval intervals))))
-               (list-&gt;vector (apply append (map array-upper-bounds-&gt;list (cons interval intervals)))))</code></pre>
+(make-interval (list-&gt;vector (apply append (map interval-lower-bounds-&gt;list (cons interval intervals))))
+               (list-&gt;vector (apply append (map interval-upper-bounds-&gt;list (cons interval intervals)))))</code></pre>
     <p>It is an error if any argument is not an interval.</p>
     <h2>Storage classes</h2>
     <p>Conceptually, a storage-class is a set of functions to manage the backing store of a specialized array.
@@ -564,11 +565,13 @@
     <p>If <code><var>bool</var></code> is <code>#t</code> then the next call to <code>specialized-array-default-safe?</code> will return <code>#t</code>;
       if <code><var>bool</var></code> is <code>#f</code> then the next call to <code>specialized-array-default-safe?</code> will return <code>#f</code>;
       otherwise it is an error.</p>
+    <p>Initially, <code>(specialized-array-default-safe?)</code> returns <code>#f</code>.</p>
     <p><b>Procedure: </b><code><a id="specialized-array-default-mutable?">specialized-array-default-mutable?</a> [ <var>bool</var> ]</code></p>
     <p>With no argument, returns <code>#t</code> if newly constructed specialized arrays are mutable by default, and <code>#f</code> otherwise.</p>
     <p>If <code><var>bool</var></code> is <code>#t</code> then the next call to <code>specialized-array-default-mutable?</code> will return <code>#t</code>;
       if <code><var>bool</var></code> is <code>#f</code> then the next call to <code>specialized-array-default-mutable?</code> will return <code>#f</code>;
       otherwise it is an error.</p>
+    <p>Initially, <code>(specialized-array-default-mutable?)</code> returns <code>#t</code>.</p>
     <p><b>Procedure: </b><code><a id="make-specialized-array">make-specialized-array</a> <var>interval</var> [ <var>storage-class</var> generic-storage-class ] [ <var>safe?</var> (specialized-array-default-safe?) ]</code></p>
     <p>Constructs a mutable specialized array from its arguments.</p>
     <p><code><var>interval</var></code> must be given as a nonempty interval. If given, <code><var>storage-class</var></code> must be a storage class; if it is not given it defaults to <code>generic-storage-class</code>. If given, <code><var>safe?</var></code> must be a boolean; if it is not given it defaults to the current value of <code>(specialized-array-default-safe?)</code>.</p>

--- a/srfi-179.scm
+++ b/srfi-179.scm
@@ -33,7 +33,7 @@
          rel: "icon"
          sizes: "192x192"
          type: "image/png"
-         href: "favicon.png"
+         href: "/favicon.png"
          )
         (<link> href: "https://srfi.schemers.org/srfi.css"
                 rel: "stylesheet"
@@ -80,7 +80,8 @@ MathJax.Hub.Config({
               (<li> "Finalized: 2020-06-30")
               (<li> "Revised to fix errata:"
                     (<ul> (<li> "2020-10-08 (Fix documentation for "(<code>'interval-subset?)".)")
-                          (<li> "2021-02-24 (Correct the note comparing  "(<code>'array-curry)" and "(<code>'array-tile)".)")))
+                          (<li> "2021-02-24 (Correct the note comparing  "(<code>'array-curry)" and "(<code>'array-tile)".)")
+                          (<li> "2021-05-02 (Correct documentation of "(<code>'interval-cartesian-product)"; document initial values for "(<code> "(specialized-array-default-safe?)")" and "(<code> "(specialized-array-default-mutable?)")".")))
               (<li> id: 'pfn1 "Post-finalization note added on 2020-12-10: The document
 was updated to improve the examples and to explain the use of "(<code>'array-copy)" to
 improve efficiency in some situations.")
@@ -612,8 +613,8 @@ the representation of $[0,16)\\times [0,4)\\times[0,8)\\times[0,21)$.")
       (<var>'intervals)
       ")")". Returns")
 (<pre>(<code>"
-(make-interval (list->vector (apply append (map array-lower-bounds->list (cons interval intervals))))
-               (list->vector (apply append (map array-upper-bounds->list (cons interval intervals)))))"))
+(make-interval (list->vector (apply append (map interval-lower-bounds->list (cons interval intervals))))
+               (list->vector (apply append (map interval-upper-bounds->list (cons interval intervals)))))"))
 (<p> "It is an error if any argument is not an interval.")
 
 (<h2> "Storage classes")
@@ -818,12 +819,15 @@ if "(<code>(<var> 'array))" is not a mutable array.")
 (<p> "If "(<code>(<var>'bool))" is "(<code>'#t)" then the next call to "(<code>'specialized-array-default-safe?)" will return "(<code>'#t)";
 if "(<code>(<var>'bool))" is "(<code>'#f)" then the next call to "(<code>'specialized-array-default-safe?)" will return "(<code>'#f)";
 otherwise it is an error.")
+(<p> "Initially, "(<code> "(specialized-array-default-safe?)")" returns "(<code>'#f)".")
 
 (format-lambda-list '(specialized-array-default-mutable? #\[ bool #\]))
 (<p> "With no argument, returns "(<code>'#t)" if newly constructed specialized arrays are mutable by default, and "(<code>'#f)" otherwise.")
 (<p> "If "(<code>(<var>'bool))" is "(<code>'#t)" then the next call to "(<code>'specialized-array-default-mutable?)" will return "(<code>'#t)";
 if "(<code>(<var>'bool))" is "(<code>'#f)" then the next call to "(<code>'specialized-array-default-mutable?)" will return "(<code>'#f)";
 otherwise it is an error.")
+(<p> "Initially, "(<code> "(specialized-array-default-mutable?)")" returns "(<code>'#t)".")
+
 
 (format-lambda-list '(make-specialized-array interval #\[ storage-class "generic-storage-class" #\] #\[ safe? "(specialized-array-default-safe?)"#\]))
 (<p> "Constructs a mutable specialized array from its arguments.")

--- a/test-arrays.scm
+++ b/test-arrays.scm
@@ -53,8 +53,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 (declare (standard-bindings)(extended-bindings)(block)(not safe) (mostly-fixnum))
 (declare (inlining-limit 0))
-(define tests 100)
-(set! tests tests)
+(define random-tests 100)
+(set! random-tests random-tests)
 
 (define total-tests 0)
 (set! total-tests total-tests)
@@ -99,10 +99,49 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ;;; requires make-list function
 
+;;; Pseudo-random infrastructure
+
+;;; The idea is to have more reproducibility in the random tests.
+;;; Our goal is that if this file is run with random-tests=N and then
+;;; run with random-tests=M>N, then the parameters of the first N of M tests in each block
+;;; will be the same as the parameters of the tests in the run with random-tests=N.
+
+;;; Call next-test-random-source-state! immediately *after* each loop that is
+;;; executed random-tests number of times.
+
+
+(define test-random-source
+  (make-random-source))
+
+(define initial-test-random-source-state
+  (random-source-state-ref test-random-source))
+
+(define next-test-random-source-state!
+  (let ((j 0))
+    (lambda ()
+      (set! j (fx+ j 1))
+      (random-source-state-set!
+       test-random-source
+       initial-test-random-source-state)
+      (random-source-pseudo-randomize!
+       test-random-source
+       0 j))))
+  
+
+(define test-random-integer
+  (random-source-make-integers
+   test-random-source))
+
+(define test-random-real
+  (random-source-make-reals
+   test-random-source))
+
+
+
 (define (random a #!optional b)
   (if b
-      (+ a (random-integer (- b a)))
-      (random-integer a)))
+      (+ a (test-random-integer (- b a)))
+      (test-random-integer a)))
 
 (define (random-sample n #!optional (l 4))
   (list->vector (map (lambda (i)
@@ -272,7 +311,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 1 11)))))
          (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
     (let ((interval (make-interval (list->vector lower)
@@ -287,6 +326,8 @@ OTHER DEALINGS IN THE SOFTWARE.
       (test (interval-upper-bounds->list interval)
             upper))))
 
+(next-test-random-source-state!)
+
 (pp "interval-lower-bounds->vector error tests")
 
 (test (interval-lower-bounds->vector 1)
@@ -300,7 +341,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "interval-lower-bound, interval-upper-bound, interval-lower-bounds->vector, and interval-upper-bounds->vector result tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 1 11)))))
          (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
     (let ((interval (make-interval (list->vector lower)
@@ -314,6 +355,8 @@ OTHER DEALINGS IN THE SOFTWARE.
             (list->vector lower))
       (test (interval-upper-bounds->vector interval)
             (list->vector upper)))))
+
+(next-test-random-source-state!)
 
 (pp "interval-projections error tests")
 
@@ -339,7 +382,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "interval-projections result tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 3 11)))))
          (upper (map (lambda (x) (+ (random 1 11) x)) lower))
          (left-dimension (random 1 (- (length lower) 1)))
@@ -352,6 +395,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                           (list->vector (take upper left-dimension)))
            (make-interval (list->vector (drop lower left-dimension))
                           (list->vector (drop upper left-dimension)))))))
+
+(next-test-random-source-state!)
 
 
 (pp "interval-contains-multi-index? error tests")
@@ -366,12 +411,14 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "interval-volume result tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower (map (lambda (x) (random 10)) (vector->list (make-vector (random 1 11)))))
          (upper (map (lambda (x) (+ (random 1 11) x)) lower)))
     (test (interval-volume (make-interval (list->vector lower)
                                           (list->vector upper)))
           (apply * (map - upper lower)))))
+
+(next-test-random-source-state!)
 
 (pp "interval= error tests")
 
@@ -384,7 +431,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "interval= result tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower1 (map (lambda (x) (random 2)) (vector->list (make-vector (random 1 6)))))
          (upper1 (map (lambda (x) (+ (random 1 3) x)) lower1))
          (lower2 (map (lambda (x) (random 2)) lower1))
@@ -395,6 +442,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                                     (list->vector upper2)))
           (and (equal? lower1 lower2)                              ;; the probability of this happening is about 1/16
                (equal? upper1 upper2)))))
+
+(next-test-random-source-state!)
 
 (pp "interval-subset? error tests")
 
@@ -411,7 +460,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "interval-subset? result tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower1 (map (lambda (x) (random 2)) (vector->list (make-vector (random 1 6)))))
          (upper1 (map (lambda (x) (+ (random 1 3) x)) lower1))
          (lower2 (map (lambda (x) (random 2)) lower1))
@@ -422,6 +471,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                                            (list->vector upper2)))
           (and (%%every (lambda (x) (>= (car x) (cdr x))) (map cons lower1 lower2))
                (%%every (lambda (x) (<= (car x) (cdr x))) (map cons upper1 upper2))))))
+
+(next-test-random-source-state!)
 
 (pp "interval-contains-multi-index?  error tests")
 
@@ -474,7 +525,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "interval-for-each result tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower (map (lambda (x) (random 10))
                      (vector->list (make-vector (random 1 7)))))
          (upper (map (lambda (x) (+ (random 1 4) x))
@@ -490,6 +541,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                                                 (list->vector upper)))
               result)
             (reverse (all-elements lower upper))))))
+
+(next-test-random-source-state!)
 
 
 (pp "interval-dilate error tests")
@@ -690,7 +743,7 @@ OTHER DEALINGS IN THE SOFTWARE.
   (- 1 (* 2 (random 2))))
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((lower-bounds
           (map (lambda (x) (random 2))
                (vector->list (make-vector (random 1 7)))))
@@ -734,6 +787,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                   base
                   coefficients
                   new-domain->old-domain-coefficients)))))
+
+(next-test-random-source-state!)
 
 (define (myarray= array1 array2)
   (and (interval= (array-domain array1)
@@ -798,14 +853,14 @@ OTHER DEALINGS IN THE SOFTWARE.
                  (lambda args (random (expt 2 64))))
            ;; float
            (list f32-storage-class
-                 (lambda args (random-real)))
+                 (lambda args (test-random-real)))
            (list f64-storage-class
-                 (lambda args (random-real)))
+                 (lambda args (test-random-real)))
            ;; complex-float
            (list c64-storage-class
-                 (lambda args (make-rectangular (random-real) (random-real))))
+                 (lambda args (make-rectangular (test-random-real) (test-random-real))))
            (list c128-storage-class
-                 (lambda args (make-rectangular (random-real) (random-real))))))
+                 (lambda args (make-rectangular (test-random-real) (test-random-real))))))
          (n
           (vector-length storage-classes)))
     (lambda ()
@@ -828,17 +883,19 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;; all these are true, we'll have to see how to screw it up later.
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let ((array
          (make-specialized-array (random-interval)
                                  u1-storage-class)))
     (test (array-elements-in-order? array)
           #t)))
 
+(next-test-random-source-state!)
+
 ;; the elements of curried arrays are in order
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval 2 5)
                                   u1-storage-class))
@@ -846,6 +903,8 @@ OTHER DEALINGS IN THE SOFTWARE.
           (array-curry base (random 1 (array-dimension base)))))
     (test (array-every array-elements-in-order? curried)
           #t)))
+
+(next-test-random-source-state!)
 
 ;; Elements of extracted arrays of newly created specialized
 ;; arrays are not in order unless
@@ -874,7 +933,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                          (loop-2 (+ i 1))))))))))
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval 2 6)
                                   u1-storage-class))
@@ -883,10 +942,12 @@ OTHER DEALINGS IN THE SOFTWARE.
     (test (array-elements-in-order? extracted)
           (extracted-array-elements-in-order? base extracted))))
 
+(next-test-random-source-state!)
+
 ;; Should we do reversed now?
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval)
                                   u1-storage-class))
@@ -905,6 +966,8 @@ OTHER DEALINGS IN THE SOFTWARE.
            (interval-lower-bounds->vector domain)
            (interval-upper-bounds->vector domain)
            reversed-dimensions))))
+
+(next-test-random-source-state!)
 
 ;; permutations
 
@@ -931,7 +994,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                       permuted-axes-and-limits))))
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-interval)
                                   u1-storage-class))
@@ -943,6 +1006,8 @@ OTHER DEALINGS IN THE SOFTWARE.
           (array-permute base permutation)))
     (test (array-elements-in-order? permuted)
           (permuted-array-elements-in-order? base permutation))))
+
+(next-test-random-source-state!)
 
 ;; a sampled array has elements in order iff after a string of
 ;; dimensions with side-length 1 at the beginning, all the rest
@@ -979,7 +1044,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                                  (cdr scaled-lengths))))))))))
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((base
           (make-specialized-array (random-nonnegative-interval 1 6)
                                    u1-storage-class))
@@ -989,6 +1054,8 @@ OTHER DEALINGS IN THE SOFTWARE.
           (array-sample base scales)))
     (test (array-elements-in-order? sampled)
           (sampled-array-elements-in-order? base scales))))
+
+(next-test-random-source-state!)
 
 ;;; Now we need to test the precomputation and caching of array-elements-in-order?
 ;;; The only places we precompute are
@@ -1004,7 +1071,7 @@ OTHER DEALINGS IN THE SOFTWARE.
         #t))
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((array
           (make-specialized-array (random-nonnegative-interval) u8-storage-class))
          (ignore  ;; compute and cache the results
@@ -1023,8 +1090,10 @@ OTHER DEALINGS IN THE SOFTWARE.
     (test (%%array-elements-in-order? translated-sampled-array)
           (%%compute-array-elements-in-order? (%%array-domain translated-sampled-array) (%%array-indexer translated-sampled-array)))))
 
+(next-test-random-source-state!)
+
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((array
           (make-specialized-array (random-nonnegative-interval 2 4) u8-storage-class))
          (d-1
@@ -1056,6 +1125,8 @@ OTHER DEALINGS IN THE SOFTWARE.
     (test (array-elements-in-order? curried-sampled-array)
           (%%compute-array-elements-in-order? (%%array-domain curried-sampled-array) (%%array-indexer curried-sampled-array)))))
          
+(next-test-random-source-state!)
+
 ;;; FIXME: array-reshape tests.
 
 
@@ -1088,7 +1159,7 @@ OTHER DEALINGS IN THE SOFTWARE.
           (make-interval (list->vector (reverse uppers-list)))))
     (do ((i 0 (fx+ i 1)))
         ;; distribute "tests" results over five dimensions
-        ((= i (quotient tests 5)))
+        ((= i (quotient random-tests 5)))
       (let* ((storage-class-and-initializer
               (random-storage-class-and-initializer))
              (storage-class
@@ -1189,6 +1260,8 @@ OTHER DEALINGS IN THE SOFTWARE.
               #t)
         ))))
 
+(next-test-random-source-state!)
+
 (pp "array-copy error tests")
 
 (test (array-copy #f generic-storage-class)
@@ -1278,7 +1351,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "Safe tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((domain
           (random-interval))
          (lower-bounds
@@ -1317,12 +1390,14 @@ OTHER DEALINGS IN THE SOFTWARE.
     (or (myarray= (array-copy array1 generic-storage-class ) array2) (pp "test3"))
     ))
 
+(next-test-random-source-state!)
+
 (specialized-array-default-safe? #f)
 
 (pp "Unsafe tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((domain
           (random-interval))
          (lower-bounds
@@ -1360,6 +1435,8 @@ OTHER DEALINGS IN THE SOFTWARE.
     (or (myarray= array1 array2) (pp "test1"))
     (or (myarray= (array-copy array1 generic-storage-class ) array2) (pp "test3"))
     ))
+
+(next-test-random-source-state!)
 
 (pp "array-map error tests")
 
@@ -1441,7 +1518,7 @@ OTHER DEALINGS IN THE SOFTWARE.
            (indices-in-proper-order (cdr l)))))
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((interval
           (random-nonnegative-interval 1 6))
          (n
@@ -1498,6 +1575,8 @@ OTHER DEALINGS IN THE SOFTWARE.
         (error "arrghh arguments-2" arguments-2))
     ))
 
+(next-test-random-source-state!)
+
 
 
 
@@ -1549,13 +1628,13 @@ OTHER DEALINGS IN THE SOFTWARE.
                               (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
                               (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
                               (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-                              (list f32-storage-class     (lambda indices (random-real)))
-                              (list f64-storage-class     (lambda indices (random-real)))
-                              (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
-                              (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list f32-storage-class     (lambda indices (test-random-real)))
+                              (list f64-storage-class     (lambda indices (test-random-real)))
+                              (list c64-storage-class     (lambda indices (make-rectangular (test-random-real) (test-random-real))))
+                              (list c128-storage-class    (lambda indices (make-rectangular (test-random-real) (test-random-real))))
                               (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain
             (random-interval))
            (lower-bounds
@@ -1608,6 +1687,8 @@ OTHER DEALINGS IN THE SOFTWARE.
           (pp "Arghh"))
       )))
 
+(next-test-random-source-state!)
+
 (specialized-array-default-safe? #f)
 
 (let ((array-builders (vector (list u1-storage-class      (lambda indices (random (expt 2 1))))
@@ -1619,13 +1700,13 @@ OTHER DEALINGS IN THE SOFTWARE.
                               (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
                               (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
                               (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-                              (list f32-storage-class     (lambda indices (random-real)))
-                              (list f64-storage-class     (lambda indices (random-real)))
-                              (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
-                              (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list f32-storage-class     (lambda indices (test-random-real)))
+                              (list f64-storage-class     (lambda indices (test-random-real)))
+                              (list c64-storage-class     (lambda indices (make-rectangular (test-random-real) (test-random-real))))
+                              (list c128-storage-class    (lambda indices (make-rectangular (test-random-real) (test-random-real))))
                               (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain
             (random-interval))
            (lower-bounds
@@ -1667,6 +1748,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                                                        result-array-2)
                                        result)))))
           (pp "Arghh")))))
+
+(next-test-random-source-state!)
 
 (pp "array-reduce tests")
 
@@ -1814,13 +1897,13 @@ OTHER DEALINGS IN THE SOFTWARE.
                               (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
                               (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
                               (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-                              (list f32-storage-class     (lambda indices (random-real)))
-                              (list f64-storage-class     (lambda indices (random-real)))
-                              (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
-                              (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list f32-storage-class     (lambda indices (test-random-real)))
+                              (list f64-storage-class     (lambda indices (test-random-real)))
+                              (list c64-storage-class     (lambda indices (make-rectangular (test-random-real) (test-random-real))))
+                              (list c128-storage-class    (lambda indices (make-rectangular (test-random-real) (test-random-real))))
                               (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain
             (random-interval 2 7))
            (lower-bounds
@@ -1933,6 +2016,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                (error "Arggh"))))))
 
 
+(next-test-random-source-state!)
+
 
 (pp "specialized-array-share error tests")
 
@@ -1962,7 +2047,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 (pp "specialized-array-share result tests")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((n (random 1 11))
          (permutation (random-permutation n))
          (input-vec (list->vector (f64vector->list (random-f64vector n)))))
@@ -1972,11 +2057,13 @@ OTHER DEALINGS IN THE SOFTWARE.
           (vector-permute input-vec permutation))))
 
 
+(next-test-random-source-state!)
+
 
 (specialized-array-default-safe? #t)
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((interval (random-interval))
          (axes (local-iota 0 (interval-dimension interval)))
          (lower-bounds (interval-lower-bounds->vector interval))
@@ -2020,11 +2107,13 @@ OTHER DEALINGS IN THE SOFTWARE.
       (if (not (myarray= b c))
           (pp (list "piffle"
                     a b c))))))
+
+(next-test-random-source-state!)
 
 (specialized-array-default-safe? #f)
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((interval (random-interval))
          (axes (local-iota 0 (interval-dimension interval)))
          (lower-bounds (interval-lower-bounds->vector interval))
@@ -2068,6 +2157,8 @@ OTHER DEALINGS IN THE SOFTWARE.
       (if (not (myarray= b c))
           (pp (list "piffle"
                     a b c))))))
+
+(next-test-random-source-state!)
 
 
 (pp "interval and array translation tests")
@@ -2085,7 +2176,7 @@ OTHER DEALINGS IN THE SOFTWARE.
   (test (interval-translate int '#(1))
         "interval-translate: The dimension of the first argument (an interval) does not equal the length of the second (a vector): ")
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((int (random-interval))
            (lower-bounds (interval-lower-bounds->vector int))
            (upper-bounds (interval-upper-bounds->vector int))
@@ -2095,6 +2186,8 @@ OTHER DEALINGS IN THE SOFTWARE.
       (interval= (interval-translate int translation)
                  (make-interval (vector-map + lower-bounds translation)
                                 (vector-map + upper-bounds translation))))))
+
+(next-test-random-source-state!)
 
 (let* ((specialized-array (array-copy (make-array (make-interval '#(0 0) '#(10 12))
                                                   list)))
@@ -2143,10 +2236,10 @@ OTHER DEALINGS IN THE SOFTWARE.
           #t))
 
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain (random-interval))
            (Array (let ((temp (make-array domain list)))
-                    (case (random-integer 3)
+                    (case (test-random-integer 3)
                       ((0) temp)
                       ((1) (array-copy temp))
                       ((2) (let ((temp (array-copy temp)))
@@ -2165,12 +2258,14 @@ OTHER DEALINGS IN THE SOFTWARE.
                     (lambda ()
                       (random-multi-index translated-domain))
                   (lambda multi-index
-                    (let ((value (random-integer 10000)))
+                    (let ((value (test-random-integer 10000)))
                       (apply (array-setter translated-array) value multi-index)
                       (apply (array-setter my-translated-array) value multi-index)))))))
         (test (myarray= (array-translate Array translation)
                         (my-array-translate Array translation))
               #t)))))
+
+(next-test-random-source-state!)
 
 (let* ((specialized (make-specialized-array (make-interval '#(0 0 0 0 0) '#(1 1 1 1 1))))
        (mutable (make-array (array-domain specialized)
@@ -2183,6 +2278,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 
   (test ((array-setter A) 'a 0 0)
         "The number of indices does not equal the array dimension: "))
+
+(next-test-random-source-state!)
 
 
 (pp "interval and array permutation tests")
@@ -2202,7 +2299,7 @@ OTHER DEALINGS IN THE SOFTWARE.
   (test (interval-permute int '#(0))
         "interval-permute: The dimension of the first argument (an interval) does not equal the length of the second (a permutation): ")
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((int (random-interval))
            (lower-bounds (interval-lower-bounds->vector int))
            (upper-bounds (interval-upper-bounds->vector int))
@@ -2210,6 +2307,8 @@ OTHER DEALINGS IN THE SOFTWARE.
       (interval= (interval-permute int permutation)
                  (make-interval (vector-permute lower-bounds permutation)
                                 (vector-permute upper-bounds permutation))))))
+
+(next-test-random-source-state!)
 
 (let* ((specialized-array (array-copy (make-array (make-interval '#(0 0) '#(10 12))
                                                                 list)))
@@ -2248,10 +2347,10 @@ OTHER DEALINGS IN THE SOFTWARE.
   (specialized-array-default-safe? #t)
 
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain (random-interval))
            (Array (let ((temp (make-array domain list)))
-                    (case (random-integer 3)
+                    (case (test-random-integer 3)
                       ((0) temp)
                       ((1) (array-copy temp))
                       ((2) (let ((temp (array-copy temp)))
@@ -2295,20 +2394,22 @@ OTHER DEALINGS IN THE SOFTWARE.
                     (lambda ()
                       (random-multi-index permuted-domain))
                   (lambda multi-index
-                    (let ((value (random-integer 10000)))
+                    (let ((value (test-random-integer 10000)))
                       (apply (array-setter permuted-array) value multi-index)
                       (apply (array-setter my-permuted-array) value multi-index)))))))
         (test (myarray= permuted-array
                         my-permuted-array)
               #t))))
 
+(next-test-random-source-state!)
+
   (specialized-array-default-safe? #f)
 
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain (random-interval))
            (Array (let ((temp (make-array domain list)))
-                    (case (random-integer 3)
+                    (case (test-random-integer 3)
                       ((0) temp)
                       ((1) (array-copy temp))
                       ((2) (let ((temp (array-copy temp)))
@@ -2352,13 +2453,15 @@ OTHER DEALINGS IN THE SOFTWARE.
                     (lambda ()
                       (random-multi-index permuted-domain))
                   (lambda multi-index
-                    (let ((value (random-integer 10000)))
+                    (let ((value (test-random-integer 10000)))
                       (apply (array-setter permuted-array) value multi-index)
                       (apply (array-setter my-permuted-array) value multi-index)))))))
         (test (myarray= permuted-array
                         my-permuted-array)
               #t))))
   )
+
+(next-test-random-source-state!)
 
 (pp "array-rotate  and interval-rotate tests")
 
@@ -2491,7 +2594,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((dimension (random 1 6))
          (number-of-intervals (random 1 4))
          (intervals (map (lambda (x)
@@ -2500,6 +2603,8 @@ OTHER DEALINGS IN THE SOFTWARE.
     ;; (pp (list intervals (apply my-interval-intersect intervals)))
     (test (apply my-interval-intersect intervals)
           (apply interval-intersect intervals))))
+
+(next-test-random-source-state!)
 
 (pp "test interval-scale and array-sample")
 
@@ -2537,11 +2642,13 @@ OTHER DEALINGS IN THE SOFTWARE.
                              scales)))
 
 (do ((i 0 (fx+ i 1)))
-    ((fx= i tests))
+    ((fx= i random-tests))
   (let* ((interval (random-nonnegative-interval))
          (scales   (random-positive-vector (interval-dimension interval))))
     (test (  interval-scale interval scales)
           (myinterval-scale interval scales))))
+
+(next-test-random-source-state!)
 
 (test (array-sample 'a 'a)
       "array-sample: The first argument is not an array whose domain has zero lower bounds: ")
@@ -2585,10 +2692,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((domain (random-nonnegative-interval 1 6))
          (Array (let ((temp (make-array domain list)))
-                  (case (random-integer 3)
+                  (case (test-random-integer 3)
                     ((0) temp)
                     ((1) (array-copy temp))
                     ((2) (let ((temp (array-copy temp)))
@@ -2607,12 +2714,14 @@ OTHER DEALINGS IN THE SOFTWARE.
                   (lambda ()
                     (random-multi-index scaled-domain))
                 (lambda multi-index
-                  (let ((value (random-integer 10000)))
+                  (let ((value (test-random-integer 10000)))
                     (apply (array-setter sampled-array) value multi-index)
                     (apply (array-setter my-sampled-array) value multi-index)))))))
       (test (myarray= sampled-array
                       my-sampled-array)
             #t)))
+
+(next-test-random-source-state!)
 
 (pp "test array-extract and array-tile")
 
@@ -2631,7 +2740,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                      (make-interval '#(0 0) '#(1 3)))
       "array-extract: The second argument (an interval) is not a subset of the domain of the first argument (an array): ")
 (do ((i 0 (fx+ i 1)))
-    ((fx= i tests))
+    ((fx= i random-tests))
   (let* ((domain (random-interval))
          (subdomain (random-subinterval domain))
          (spec-A (array-copy (make-array domain list)))
@@ -2683,13 +2792,15 @@ OTHER DEALINGS IN THE SOFTWARE.
                         (lambda ()
                           (random-multi-index subdomain))
                       (lambda multi-index
-                        (let ((val (random-real)))
+                        (let ((val (test-random-real)))
                           (apply A-setter val multi-index)
                           (apply B-extract-setter val multi-index)))))))
               (list spec-A mut-A)
               (list spec-B mut-B)
               (list spec-A-extract mut-A-extract)
               (list spec-B-extract mut-B-extract))))
+
+(next-test-random-source-state!)
 
 
 (test (array-tile 'a '#(10))
@@ -2747,12 +2858,12 @@ OTHER DEALINGS IN THE SOFTWARE.
                                    (make-interval result-lowers result-uppers)))))))
 
 (do ((i 0 (fx+ i 1)))
-    ((fx= i tests))
+    ((fx= i random-tests))
   (let* ((domain
           (random-interval))
          (array
           (let ((res (make-array domain list)))
-            (case (random-integer 3)
+            (case (test-random-integer 3)
               ;; immutable
               ((0) res)
               ;; specialized
@@ -2795,6 +2906,8 @@ OTHER DEALINGS IN THE SOFTWARE.
     (test (myarray= (apply (array-getter result) (make-list (vector-length lowers) 0))
                     (apply (array-getter test-result) (make-list (vector-length lowers) 0)))
           #t)))
+
+(next-test-random-source-state!)
 
 (pp "array-reverse tests")
 
@@ -2847,10 +2960,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((domain (random-interval))
          (Array (let ((temp (make-array domain list)))
-                  (case (random-integer 3)
+                  (case (test-random-integer 3)
                     ((0) temp)
                     ((1) (array-copy temp))
                     ((2) (let ((temp (array-copy temp)))
@@ -2868,12 +2981,14 @@ OTHER DEALINGS IN THE SOFTWARE.
               (lambda ()
                 (random-multi-index domain))
             (lambda multi-index
-              (let ((value (random-integer 10000)))
+              (let ((value (test-random-integer 10000)))
                 (apply (array-setter reversed-array) value multi-index)
                 (apply (array-setter my-reversed-array) value multi-index))))))
     (test (myarray= reversed-array
                     my-reversed-array)
           #t)))
+
+(next-test-random-source-state!)
 
 ;; next test that the optional flip? argument is computed correctly.
 
@@ -2980,7 +3095,7 @@ OTHER DEALINGS IN THE SOFTWARE.
           "array-setter: value cannot be stored in body: ")))
 
 (do ((i 0 (fx+ i 1)))
-    ((fx= i tests))
+    ((fx= i random-tests))
   (let* ((interval
           (random-interval))
          (subinterval
@@ -3029,6 +3144,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                                       (apply (array-getter mutable-array) multi-index)))))
           #t)))
 
+(next-test-random-source-state!)
+
 (pp "Miscellaneous error tests")
 
 (test (make-array (make-interval '#(0 0) '#(10 10))
@@ -3065,15 +3182,15 @@ OTHER DEALINGS IN THE SOFTWARE.
                               (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))) `(a ,(expt 2 16)))
                               (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))) `(a ,(expt 2 32)))
                               (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))) `(a ,(expt 2 64)))
-                              (list f32-storage-class     (lambda indices (random-real)) `(a 1))
-                              (list f64-storage-class     (lambda indices (random-real)) `(a 1))
-                              (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))) `(a 1))
-                              (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))) `(a 1))
+                              (list f32-storage-class     (lambda indices (test-random-real)) `(a 1))
+                              (list f64-storage-class     (lambda indices (test-random-real)) `(a 1))
+                              (list c64-storage-class     (lambda indices (make-rectangular (test-random-real) (test-random-real))) `(a 1))
+                              (list c128-storage-class    (lambda indices (make-rectangular (test-random-real) (test-random-real))) `(a 1))
                               )))
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain (random-interval))
-           (builders (vector-ref array-builders (random-integer (vector-length array-builders))))
+           (builders (vector-ref array-builders (test-random-integer (vector-length array-builders))))
            (storage-class (car builders))
            (random-entry (cadr builders))
            (invalid-entry (list-ref (caddr builders) (random 2)))
@@ -3108,6 +3225,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                   "array-getter: multi-index is not the correct dimension: ")
             (test (apply setter 10 valid-args)
                   "array-setter: multi-index is not the correct dimension: "))))))
+
+(next-test-random-source-state!)
 
 (pp "array->list and list->array")
 
@@ -3150,15 +3269,15 @@ OTHER DEALINGS IN THE SOFTWARE.
                               (list s16-storage-class     (lambda indices (random (- (expt 2 15)) (expt 2 15))))
                               (list s32-storage-class     (lambda indices (random (- (expt 2 31)) (expt 2 31))))
                               (list s64-storage-class     (lambda indices (random (- (expt 2 63)) (expt 2 63))))
-                              (list f32-storage-class     (lambda indices (random-real)))
-                              (list f64-storage-class     (lambda indices (random-real)))
-                              (list c64-storage-class     (lambda indices (make-rectangular (random-real) (random-real))))
-                              (list c128-storage-class    (lambda indices (make-rectangular (random-real) (random-real))))
+                              (list f32-storage-class     (lambda indices (test-random-real)))
+                              (list f64-storage-class     (lambda indices (test-random-real)))
+                              (list c64-storage-class     (lambda indices (make-rectangular (test-random-real) (test-random-real))))
+                              (list c128-storage-class    (lambda indices (make-rectangular (test-random-real) (test-random-real))))
                               (list generic-storage-class (lambda indices indices)))))
   (do ((i 0 (+ i 1)))
-      ((= i tests))
+      ((= i random-tests))
     (let* ((domain (random-interval))
-           (builders (vector-ref array-builders (random-integer (vector-length array-builders))))
+           (builders (vector-ref array-builders (test-random-integer (vector-length array-builders))))
            (storage-class (car builders))
            (random-entry (cadr builders))
            (Array (array-copy (make-array domain random-entry)
@@ -3166,9 +3285,11 @@ OTHER DEALINGS IN THE SOFTWARE.
                               #f
                               #t)) ; safe
            (l (array->list Array))
-           (new-array (list->array l domain storage-class (zero? (random-integer 2)))))
+           (new-array (list->array l domain storage-class (zero? (test-random-integer 2)))))
       (test (myarray= Array new-array)
             #t))))
+
+(next-test-random-source-state!)
 
 (pp "interval-cartesian-product and array-outer-product")
 
@@ -3183,13 +3304,15 @@ OTHER DEALINGS IN THE SOFTWARE.
       "interval-cartesian-product: Not all arguments are intervals: ")
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((intervals
           (map (lambda (ignore)
                  (random-interval 1 4))
                (make-list (random 1 3)))))
     (test (apply interval-cartesian-product intervals)
           (apply my-interval-cartesian-product intervals))))
+
+(next-test-random-source-state!)
 
 (let ((test-array (make-array  (make-interval '#(0) '#(1)) list)))
 
@@ -3203,7 +3326,7 @@ OTHER DEALINGS IN THE SOFTWARE.
         "array-outer-product: The third argument is not an array: "))
 
 (do ((i 0 (+ i 1)))
-    ((= i tests))
+    ((= i random-tests))
   (let* ((arrays
           (map (lambda (ignore)
                  (make-array (random-interval 1 5) list))
@@ -3212,6 +3335,8 @@ OTHER DEALINGS IN THE SOFTWARE.
                     (make-array (apply my-interval-cartesian-product (map array-domain arrays))
                                 list))
           #t)))
+
+(next-test-random-source-state!)
 
 
 (pp "array-ref and array-set! tests")
@@ -4077,9 +4202,9 @@ that computes the componentwise products when we need them, the times are
 
 (define interval-2x2  (make-interval '#(100 100 2 2)))
 
-(define A (array-copy (make-array interval-flat (lambda args (random-integer 5)))))
+(define A (array-copy (make-array interval-flat (lambda args (test-random-integer 5)))))
 
-(define B (array-copy (make-array interval-flat (lambda args (random-integer 5)))))
+(define B (array-copy (make-array interval-flat (lambda args (test-random-integer 5)))))
 
 (define C (array-copy (make-array interval-flat (lambda args 0))))
 


### PR DESCRIPTION
test-arrays.scm:

1.  The use of random numbers is changed so that if the test file is run with M random tests in each set, and then run separately with N>M random tests in each set, then the first M of N random tests are the same as in the first run.

2. Introduce and use a new SRFI 27 random source to use in random tests.  Use it to generate random integers and flonums as needed.  Set it to a known state after each set of random tests.

srfi-179.scm:

1.  Correct typo: Use interval-lower/upper-bounds->list instead of array-lower/upper-bounds->list.

2.  Specify that (specialized-array-default-safe?) initially returns #f and (specialized-array-default-mutable?) initially returns #t.

3.  Add errata fix note.

srfi-179.html:

1.  Regenerate from srfi-179.scm.